### PR TITLE
Retirei os campos de auditoria do DTO por hora

### DIFF
--- a/src/main/java/com/diario/de/classe/modules/avaliacao/dto/AlunoAvaliacaoDTO.java
+++ b/src/main/java/com/diario/de/classe/modules/avaliacao/dto/AlunoAvaliacaoDTO.java
@@ -6,7 +6,6 @@ import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 import java.io.Serializable;
-import java.util.Date;
 
 @Data
 public class AlunoAvaliacaoDTO implements Serializable {
@@ -25,9 +24,6 @@ public class AlunoAvaliacaoDTO implements Serializable {
     @Size(max = 255)
     private String obs;
 
-    private Date createdAt;
-    private Date updatedAt;
-
     public AlunoAvaliacaoDTO() {}
 
     public AlunoAvaliacaoDTO(AlunoAvaliacao entity) {
@@ -37,8 +33,6 @@ public class AlunoAvaliacaoDTO implements Serializable {
             this.idAvaliacao = entity.getAvaliacao() != null ? entity.getAvaliacao().getIdAvaliacao() : null;
             this.nota = entity.getNota();
             this.obs = entity.getObs();
-            this.createdAt = entity.getCreatedAt();
-            this.updatedAt = entity.getUpdatedAt();
         }
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/avaliacao/dto/AvaliacaoDTO.java
+++ b/src/main/java/com/diario/de/classe/modules/avaliacao/dto/AvaliacaoDTO.java
@@ -25,9 +25,6 @@ public class AvaliacaoDTO implements Serializable {
     @Size(max = 255)
     private String dia;
 
-    private Date createdAt;
-    private Date updatedAt;
-
     public AvaliacaoDTO() {}
 
     public AvaliacaoDTO(Avaliacao entity) {
@@ -37,8 +34,6 @@ public class AvaliacaoDTO implements Serializable {
             this.idCalendarioEscolar = entity.getCalendarioEscolar() != null ? entity.getCalendarioEscolar().getIdCalendarioEscolar() : null;
             this.materia = entity.getMateria();
             this.dia = entity.getDia();
-            this.createdAt = entity.getCreatedAt();
-            this.updatedAt = entity.getUpdatedAt();
         }
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/calendario/dto/CalendarioEscolarDTO.java
+++ b/src/main/java/com/diario/de/classe/modules/calendario/dto/CalendarioEscolarDTO.java
@@ -7,7 +7,6 @@ import lombok.Data;
 import org.springframework.beans.BeanUtils;
 
 import java.io.Serializable;
-import java.util.Date;
 
 @Data
 public class CalendarioEscolarDTO implements Serializable {
@@ -31,9 +30,6 @@ public class CalendarioEscolarDTO implements Serializable {
 
     @Size(max = 255)
     private String diasAvaliacoes;
-
-    private Date createdAt;
-    private Date updatedAt;
 
     public CalendarioEscolarDTO() {}
 

--- a/src/main/java/com/diario/de/classe/modules/frequencia/dto/AlunoFrequenciaDTO.java
+++ b/src/main/java/com/diario/de/classe/modules/frequencia/dto/AlunoFrequenciaDTO.java
@@ -7,7 +7,6 @@ import lombok.Data;
 import org.springframework.beans.BeanUtils;
 
 import java.io.Serializable;
-import java.util.Date;
 
 @Data
 public class AlunoFrequenciaDTO implements Serializable {
@@ -23,9 +22,6 @@ public class AlunoFrequenciaDTO implements Serializable {
 
     @Size(max = 255)
     private String faltas;
-
-    private Date createdAt;
-    private Date updatedAt;
 
     public AlunoFrequenciaDTO() {}
 

--- a/src/main/java/com/diario/de/classe/modules/turma/dto/AlunoTurmaDTO.java
+++ b/src/main/java/com/diario/de/classe/modules/turma/dto/AlunoTurmaDTO.java
@@ -7,7 +7,6 @@ import lombok.Data;
 import org.springframework.beans.BeanUtils;
 
 import java.io.Serializable;
-import java.util.Date;
 
 @Data
 public class AlunoTurmaDTO implements Serializable {
@@ -23,9 +22,6 @@ public class AlunoTurmaDTO implements Serializable {
 
     @Size(max = 255)
     private String obs;
-
-    private Date createdAt;
-    private Date updatedAt;
 
     public AlunoTurmaDTO() {}
 

--- a/src/main/java/com/diario/de/classe/modules/turma/dto/ClasseDTO.java
+++ b/src/main/java/com/diario/de/classe/modules/turma/dto/ClasseDTO.java
@@ -6,7 +6,6 @@ import lombok.Data;
 import org.springframework.beans.BeanUtils;
 
 import java.io.Serializable;
-import java.util.Date;
 
 @Data
 public class ClasseDTO implements Serializable {
@@ -30,9 +29,6 @@ public class ClasseDTO implements Serializable {
 
     @NotNull
     private Long idProfessor;
-
-    private Date createdAt;
-    private Date updatedAt;
 
     public ClasseDTO() {}
 


### PR DESCRIPTION
- Campos de auditoria gerenciados automaticamente pelo backend
- O cliente nunca os envia (RequestDTO), e se precisar recebê-los (ResponseDTO) isso será tratado na ETAPA 4 quando separar Request/Response
- Por enquanto: remover de todos os DTOs