### PR TITLE
Adaptado para Flyway e criacao dos migrations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,16 @@
 			<artifactId>h2</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+		<!-- Flyway: gerenciamento de migrations do banco de dados -->
+		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-core</artifactId>
+		</dependency>
+		<!-- flyway-mysql é obrigatório para MySQL/MariaDB no Flyway 9+ -->
+		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-mysql</artifactId>
+		</dependency>
 		<!--	Database - End	-->
 
 		<!--	Spring boot - Start	-->

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -5,9 +5,20 @@ spring.datasource.password=
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # Configuracao do Hibernate
-spring.jpa.hibernate.ddl-auto=update
+# 'none' = Flyway gerencia o schema; Hibernate nao toca nas tabelas.
+# Trocar para 'validate' quando as migrations estiverem 100% alinhadas com as entidades.
+spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+
+# Flyway — gerenciamento de migrations
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration
+# baseline-on-migrate=true permite rodar o Flyway em um banco ja existente:
+# ele marca o banco como "baseline na versao 0" e aplica as migrations a partir da V1.
+# Necessario apenas na primeira vez em um banco que ja tinha dados (criado com ddl-auto=update).
+spring.flyway.baseline-on-migrate=true
+spring.flyway.baseline-version=0
 
 # Configuracoes de conexao
 spring.jpa.properties.hibernate.connection.characterEncoding=utf-8

--- a/src/main/resources/db/migration/V1__create_pessoa_tables.sql
+++ b/src/main/resources/db/migration/V1__create_pessoa_tables.sql
@@ -1,0 +1,113 @@
+-- =============================================================================
+-- V1 — Tabelas do módulo Pessoa
+-- Cria as tabelas relacionadas a pessoas do sistema (alunos, professores,
+-- responsáveis) e seus dados de contato e endereço.
+--
+-- Nota: Todas as tabelas incluem os campos de auditoria herdados de BaseEntity:
+--   created_at, updated_at — gerenciados pelo Spring Data JPA Auditing
+--   deleted_at, ativo      — soft delete (nunca deletar fisicamente)
+-- =============================================================================
+
+-- Categoriza o tipo de uma pessoa: ALUNO, PROFESSOR, RESPONSAVEL, etc.
+CREATE TABLE IF NOT EXISTS tipo_pessoa (
+    id_tipo_pessoa  BIGINT          NOT NULL AUTO_INCREMENT,
+    nome            VARCHAR(255),
+    created_at      DATETIME        NOT NULL DEFAULT NOW(),
+    updated_at      DATETIME        NOT NULL DEFAULT NOW(),
+    deleted_at      DATETIME        NULL,
+    ativo           BOOLEAN         NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (id_tipo_pessoa)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Representa qualquer pessoa no sistema (aluno, professor, responsável, etc.).
+-- O tipo é determinado pelo relacionamento com tipo_pessoa.
+CREATE TABLE IF NOT EXISTS pessoa (
+    id_pessoa       BIGINT          NOT NULL AUTO_INCREMENT,
+    id_tipo_pessoa  BIGINT          NOT NULL,
+    nome            VARCHAR(255),
+    sexo            VARCHAR(255),
+    data_nascimento VARCHAR(255),
+    situacao        VARCHAR(255),
+    obs             VARCHAR(255),
+    created_at      DATETIME        NOT NULL DEFAULT NOW(),
+    updated_at      DATETIME        NOT NULL DEFAULT NOW(),
+    deleted_at      DATETIME        NULL,
+    ativo           BOOLEAN         NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (id_pessoa),
+    CONSTRAINT fk_id_tipo_pessoa FOREIGN KEY (id_tipo_pessoa) REFERENCES tipo_pessoa (id_tipo_pessoa)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Representa um meio de contato (telefone, e-mail, etc.) sem vínculo direto com Pessoa.
+CREATE TABLE IF NOT EXISTS contato (
+    id_contato      BIGINT          NOT NULL AUTO_INCREMENT,
+    tipo_contato    VARCHAR(255),
+    contato         VARCHAR(255),
+    created_at      DATETIME        NOT NULL DEFAULT NOW(),
+    updated_at      DATETIME        NOT NULL DEFAULT NOW(),
+    deleted_at      DATETIME        NULL,
+    ativo           BOOLEAN         NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (id_contato)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Tabela de associação N:N entre Pessoa e Contato, com atributo 'nome'.
+CREATE TABLE IF NOT EXISTS contato_pessoa (
+    id_contato_pessoa   BIGINT      NOT NULL AUTO_INCREMENT,
+    id_pessoa           BIGINT      NOT NULL,
+    id_contato          BIGINT      NOT NULL,
+    nome                VARCHAR(255),
+    created_at          DATETIME    NOT NULL DEFAULT NOW(),
+    updated_at          DATETIME    NOT NULL DEFAULT NOW(),
+    deleted_at          DATETIME    NULL,
+    ativo               BOOLEAN     NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (id_contato_pessoa),
+    CONSTRAINT fk_contato_pessoa_pessoa  FOREIGN KEY (id_pessoa)  REFERENCES pessoa  (id_pessoa),
+    CONSTRAINT fk_contato_pessoa_contato FOREIGN KEY (id_contato) REFERENCES contato (id_contato)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Representa um endereço sem vínculo direto com uma Pessoa.
+CREATE TABLE IF NOT EXISTS endereco (
+    id_endereco     BIGINT          NOT NULL AUTO_INCREMENT,
+    uf              VARCHAR(255),
+    cidade          VARCHAR(255),
+    bairro          VARCHAR(255),
+    rua             VARCHAR(255),
+    numero          VARCHAR(255),
+    cep             VARCHAR(255),
+    complemento     VARCHAR(255),
+    created_at      DATETIME        NOT NULL DEFAULT NOW(),
+    updated_at      DATETIME        NOT NULL DEFAULT NOW(),
+    deleted_at      DATETIME        NULL,
+    ativo           BOOLEAN         NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (id_endereco)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Tabela de associação N:N entre Pessoa e Endereco, com atributo 'nome'.
+CREATE TABLE IF NOT EXISTS endereco_pessoa (
+    id_endereco_pessoa  BIGINT      NOT NULL AUTO_INCREMENT,
+    id_pessoa           BIGINT      NOT NULL,
+    id_endereco         BIGINT      NOT NULL,
+    nome                VARCHAR(255),
+    created_at          DATETIME    NOT NULL DEFAULT NOW(),
+    updated_at          DATETIME    NOT NULL DEFAULT NOW(),
+    deleted_at          DATETIME    NULL,
+    ativo               BOOLEAN     NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (id_endereco_pessoa),
+    CONSTRAINT fk_endereco_pessoa_pessoa   FOREIGN KEY (id_pessoa)   REFERENCES pessoa   (id_pessoa),
+    CONSTRAINT fk_endereco_pessoa_endereco FOREIGN KEY (id_endereco) REFERENCES endereco (id_endereco)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Associação entre aluno (Pessoa tipo ALUNO) e seu responsável legal.
+-- Um aluno pode ter múltiplos responsáveis (pai, mãe, tutor).
+CREATE TABLE IF NOT EXISTS pessoa_responsavel (
+    id_pessoa_responsavel   BIGINT      NOT NULL AUTO_INCREMENT,
+    id_aluno                BIGINT      NOT NULL,
+    id_responsavel          BIGINT      NOT NULL,
+    parentesco              VARCHAR(255),
+    created_at              DATETIME    NOT NULL DEFAULT NOW(),
+    updated_at              DATETIME    NOT NULL DEFAULT NOW(),
+    deleted_at              DATETIME    NULL,
+    ativo                   BOOLEAN     NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (id_pessoa_responsavel),
+    CONSTRAINT fk_id_aluno      FOREIGN KEY (id_aluno)      REFERENCES pessoa (id_pessoa),
+    CONSTRAINT fk_id_responsavel FOREIGN KEY (id_responsavel) REFERENCES pessoa (id_pessoa)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/main/resources/db/migration/V2__create_instituicao_tables.sql
+++ b/src/main/resources/db/migration/V2__create_instituicao_tables.sql
@@ -1,0 +1,78 @@
+-- =============================================================================
+-- V2 — Tabelas do módulo Instituição
+-- Cria as tabelas que descrevem a estrutura pedagógica da instituição:
+-- tipo de ensino, grau, série, curso, turno e a própria instituição.
+-- =============================================================================
+
+-- Nível de ensino: Ensino Fundamental, Ensino Médio, etc.
+CREATE TABLE IF NOT EXISTS ensino (
+    id_ensino   BIGINT      NOT NULL AUTO_INCREMENT,
+    nome        VARCHAR(255),
+    created_at  DATETIME    NOT NULL DEFAULT NOW(),
+    updated_at  DATETIME    NOT NULL DEFAULT NOW(),
+    deleted_at  DATETIME    NULL,
+    ativo       BOOLEAN     NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (id_ensino)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Grau de ensino: 1º grau, 2º grau, etc.
+CREATE TABLE IF NOT EXISTS grau (
+    id_grau     BIGINT      NOT NULL AUTO_INCREMENT,
+    nome        VARCHAR(255),
+    created_at  DATETIME    NOT NULL DEFAULT NOW(),
+    updated_at  DATETIME    NOT NULL DEFAULT NOW(),
+    deleted_at  DATETIME    NULL,
+    ativo       BOOLEAN     NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (id_grau)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Série/ano escolar: 1ª série, 2º ano, etc.
+CREATE TABLE IF NOT EXISTS serie (
+    id_serie    BIGINT      NOT NULL AUTO_INCREMENT,
+    nome        VARCHAR(255),
+    created_at  DATETIME    NOT NULL DEFAULT NOW(),
+    updated_at  DATETIME    NOT NULL DEFAULT NOW(),
+    deleted_at  DATETIME    NULL,
+    ativo       BOOLEAN     NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (id_serie)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Turno de funcionamento das turmas: Manhã, Tarde, Noite.
+CREATE TABLE IF NOT EXISTS turno (
+    id_turno    BIGINT      NOT NULL AUTO_INCREMENT,
+    nome        VARCHAR(255),
+    created_at  DATETIME    NOT NULL DEFAULT NOW(),
+    updated_at  DATETIME    NOT NULL DEFAULT NOW(),
+    deleted_at  DATETIME    NULL,
+    ativo       BOOLEAN     NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (id_turno)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Representa uma instituição de ensino (escola, colégio, etc.).
+CREATE TABLE IF NOT EXISTS instituicao_ensino (
+    id_instituicao_ensino   BIGINT      NOT NULL AUTO_INCREMENT,
+    descricao               VARCHAR(255),
+    codigo_estadual         VARCHAR(255),
+    created_at              DATETIME    NOT NULL DEFAULT NOW(),
+    updated_at              DATETIME    NOT NULL DEFAULT NOW(),
+    deleted_at              DATETIME    NULL,
+    ativo                   BOOLEAN     NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (id_instituicao_ensino)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Curso oferecido pela instituição: combinação de Ensino + Grau + Série.
+-- Ex: Ensino Fundamental + 1º Grau + 5ª Série.
+CREATE TABLE IF NOT EXISTS curso (
+    id_curso    BIGINT      NOT NULL AUTO_INCREMENT,
+    id_ensino   BIGINT      NOT NULL,
+    id_grau     BIGINT      NOT NULL,
+    id_serie    BIGINT      NOT NULL,
+    created_at  DATETIME    NOT NULL DEFAULT NOW(),
+    updated_at  DATETIME    NOT NULL DEFAULT NOW(),
+    deleted_at  DATETIME    NULL,
+    ativo       BOOLEAN     NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (id_curso),
+    CONSTRAINT fk_id_ensino FOREIGN KEY (id_ensino) REFERENCES ensino (id_ensino),
+    CONSTRAINT fk_id_grau   FOREIGN KEY (id_grau)   REFERENCES grau   (id_grau),
+    CONSTRAINT fk_id_serie  FOREIGN KEY (id_serie)  REFERENCES serie  (id_serie)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/main/resources/db/migration/V3__create_turma_tables.sql
+++ b/src/main/resources/db/migration/V3__create_turma_tables.sql
@@ -1,0 +1,39 @@
+-- =============================================================================
+-- V3 — Tabelas do módulo Turma (parte 1: entidades independentes)
+-- Turma, ComponenteCurricular e Disciplina não têm dependências externas.
+-- Classe e AlunoTurma (que dependem de Pessoa e Instituição) ficam em V4.
+-- =============================================================================
+
+-- Turma: agrupamento de alunos (ex: 5A, 6B).
+CREATE TABLE IF NOT EXISTS turma (
+    id_turma    BIGINT      NOT NULL AUTO_INCREMENT,
+    nome        VARCHAR(255),
+    created_at  DATETIME    NOT NULL DEFAULT NOW(),
+    updated_at  DATETIME    NOT NULL DEFAULT NOW(),
+    deleted_at  DATETIME    NULL,
+    ativo       BOOLEAN     NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (id_turma)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Componente curricular: área de conhecimento (ex: Matemática, Língua Portuguesa).
+CREATE TABLE IF NOT EXISTS componente_curricular (
+    id_componente_curricular    BIGINT      NOT NULL AUTO_INCREMENT,
+    nome                        VARCHAR(255),
+    obs                         VARCHAR(255),
+    created_at                  DATETIME    NOT NULL DEFAULT NOW(),
+    updated_at                  DATETIME    NOT NULL DEFAULT NOW(),
+    deleted_at                  DATETIME    NULL,
+    ativo                       BOOLEAN     NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (id_componente_curricular)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Disciplina específica dentro de um componente curricular.
+CREATE TABLE IF NOT EXISTS disciplina (
+    id_disciplina   BIGINT      NOT NULL AUTO_INCREMENT,
+    nome            VARCHAR(255),
+    created_at      DATETIME    NOT NULL DEFAULT NOW(),
+    updated_at      DATETIME    NOT NULL DEFAULT NOW(),
+    deleted_at      DATETIME    NULL,
+    ativo           BOOLEAN     NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (id_disciplina)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/main/resources/db/migration/V4__create_classe_turma_tables.sql
+++ b/src/main/resources/db/migration/V4__create_classe_turma_tables.sql
@@ -1,0 +1,48 @@
+-- =============================================================================
+-- V4 — Tabelas do módulo Turma (parte 2: Classe e AlunoTurma)
+-- Depende de: V1 (pessoa), V2 (instituicao_ensino, curso, turno),
+--             V3 (turma, componente_curricular).
+--
+-- Classe representa uma turma em um contexto específico: a combinação de
+-- uma turma, um professor, um curso, uma instituição e um componente curricular.
+-- É o "diário de classe" propriamente dito.
+-- =============================================================================
+
+-- Classe: associa turma + professor + instituição + curso + turno + componente.
+-- É a entidade central do sistema — o professor lança frequência e notas pela Classe.
+CREATE TABLE IF NOT EXISTS classe (
+    id_classe                   BIGINT      NOT NULL AUTO_INCREMENT,
+    id_instituicao_ensino       BIGINT      NOT NULL,
+    id_componente_curricular    BIGINT,                  -- nullable: turma pode não ter componente definido
+    id_curso                    BIGINT      NOT NULL,
+    id_turno                    BIGINT      NOT NULL,
+    id_turma                    BIGINT      NOT NULL,
+    id_professor                BIGINT      NOT NULL,    -- FK para pessoa (tipo PROFESSOR)
+    created_at                  DATETIME    NOT NULL DEFAULT NOW(),
+    updated_at                  DATETIME    NOT NULL DEFAULT NOW(),
+    deleted_at                  DATETIME    NULL,
+    ativo                       BOOLEAN     NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (id_classe),
+    CONSTRAINT fk_id_instituicao_ensino    FOREIGN KEY (id_instituicao_ensino)    REFERENCES instituicao_ensino    (id_instituicao_ensino),
+    CONSTRAINT fk_id_componente_curricular FOREIGN KEY (id_componente_curricular) REFERENCES componente_curricular (id_componente_curricular),
+    CONSTRAINT fk_id_curso                 FOREIGN KEY (id_curso)                 REFERENCES curso                 (id_curso),
+    CONSTRAINT fk_id_turno                 FOREIGN KEY (id_turno)                 REFERENCES turno                 (id_turno),
+    CONSTRAINT fk_id_turma                 FOREIGN KEY (id_turma)                 REFERENCES turma                 (id_turma),
+    CONSTRAINT fk_id_professor             FOREIGN KEY (id_professor)             REFERENCES pessoa                (id_pessoa)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Matrícula do aluno em uma turma.
+-- Um aluno pode estar em múltiplas turmas ao longo dos anos.
+CREATE TABLE IF NOT EXISTS aluno_turma (
+    id_aluno_turma  BIGINT      NOT NULL AUTO_INCREMENT,
+    id_aluno        BIGINT      NOT NULL,    -- FK para pessoa (tipo ALUNO)
+    id_turma        BIGINT      NOT NULL,
+    obs             VARCHAR(255),
+    created_at      DATETIME    NOT NULL DEFAULT NOW(),
+    updated_at      DATETIME    NOT NULL DEFAULT NOW(),
+    deleted_at      DATETIME    NULL,
+    ativo           BOOLEAN     NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (id_aluno_turma),
+    CONSTRAINT fk_aluno_turma_aluno FOREIGN KEY (id_aluno) REFERENCES pessoa (id_pessoa),
+    CONSTRAINT fk_aluno_turma_turma FOREIGN KEY (id_turma) REFERENCES turma  (id_turma)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/main/resources/db/migration/V5__create_calendario_tables.sql
+++ b/src/main/resources/db/migration/V5__create_calendario_tables.sql
@@ -1,0 +1,61 @@
+-- =============================================================================
+-- V5 — Tabelas do módulo Calendário
+-- Depende de: V4 (classe).
+--
+-- O calendário escolar organiza as aulas por mês e período dentro de uma classe.
+-- É a referência usada pelo lançamento de frequência e avaliações.
+-- =============================================================================
+
+-- Ano letivo de referência.
+CREATE TABLE IF NOT EXISTS ano_calendario (
+    id_ano_calendario   BIGINT      NOT NULL AUTO_INCREMENT,
+    ano                 VARCHAR(255),
+    created_at          DATETIME    NOT NULL DEFAULT NOW(),
+    updated_at          DATETIME    NOT NULL DEFAULT NOW(),
+    deleted_at          DATETIME    NULL,
+    ativo               BOOLEAN     NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (id_ano_calendario)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Mês do calendário (Janeiro, Fevereiro, ..., Dezembro).
+CREATE TABLE IF NOT EXISTS mes (
+    id_mes      BIGINT      NOT NULL AUTO_INCREMENT,
+    nome        VARCHAR(255),
+    created_at  DATETIME    NOT NULL DEFAULT NOW(),
+    updated_at  DATETIME    NOT NULL DEFAULT NOW(),
+    deleted_at  DATETIME    NULL,
+    ativo       BOOLEAN     NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (id_mes)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Período letivo: 1º Bimestre, 2º Bimestre, etc.
+CREATE TABLE IF NOT EXISTS periodo (
+    id_periodo  BIGINT      NOT NULL AUTO_INCREMENT,
+    nome        VARCHAR(255),
+    created_at  DATETIME    NOT NULL DEFAULT NOW(),
+    updated_at  DATETIME    NOT NULL DEFAULT NOW(),
+    deleted_at  DATETIME    NULL,
+    ativo       BOOLEAN     NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (id_periodo)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Calendário escolar: vínculo entre uma Classe e um mês/período específico.
+-- Registra os dias letivos e dias de avaliação daquele mês/período/classe.
+CREATE TABLE IF NOT EXISTS calendario_escolar (
+    id_calendario_escolar   BIGINT      NOT NULL AUTO_INCREMENT,
+    id_mes                  BIGINT      NOT NULL,
+    id_ano_calendario       BIGINT,             -- nullable: pode ser preenchido depois
+    id_periodo              BIGINT      NOT NULL,
+    id_classe               BIGINT      NOT NULL,
+    dias_letivos            VARCHAR(255),
+    dias_avaliacoes         VARCHAR(255),
+    created_at              DATETIME    NOT NULL DEFAULT NOW(),
+    updated_at              DATETIME    NOT NULL DEFAULT NOW(),
+    deleted_at              DATETIME    NULL,
+    ativo                   BOOLEAN     NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (id_calendario_escolar),
+    CONSTRAINT fk_calendario_mes           FOREIGN KEY (id_mes)           REFERENCES mes            (id_mes),
+    CONSTRAINT fk_calendario_ano           FOREIGN KEY (id_ano_calendario) REFERENCES ano_calendario (id_ano_calendario),
+    CONSTRAINT fk_calendario_periodo       FOREIGN KEY (id_periodo)        REFERENCES periodo        (id_periodo),
+    CONSTRAINT fk_calendario_classe        FOREIGN KEY (id_classe)         REFERENCES classe         (id_classe)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/main/resources/db/migration/V6__create_frequencia_avaliacao_tables.sql
+++ b/src/main/resources/db/migration/V6__create_frequencia_avaliacao_tables.sql
@@ -1,0 +1,57 @@
+-- =============================================================================
+-- V6 — Tabelas dos módulos Frequência e Avaliação
+-- Depende de: V1 (pessoa), V5 (calendario_escolar), V3 (disciplina).
+--
+-- Frequência: registra a presença ou falta de cada aluno em cada aula.
+-- Avaliação:  registra as avaliações (provas, trabalhos) e as notas dos alunos.
+-- =============================================================================
+
+-- Registro de frequência de um aluno em um calendário escolar (aula/mês).
+-- Tipos de falta: PRESENTE, FALTA, FALTA_JUSTIFICADA (ver regra da LDB Art. 24).
+CREATE TABLE IF NOT EXISTS aluno_frequencia (
+    id_aluno_frequencia     BIGINT      NOT NULL AUTO_INCREMENT,
+    id_aluno                BIGINT      NOT NULL,   -- FK para pessoa (tipo ALUNO)
+    id_calendario_escolar   BIGINT      NOT NULL,
+    faltas                  VARCHAR(255),
+    created_at              DATETIME    NOT NULL DEFAULT NOW(),
+    updated_at              DATETIME    NOT NULL DEFAULT NOW(),
+    deleted_at              DATETIME    NULL,
+    ativo                   BOOLEAN     NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (id_aluno_frequencia),
+    CONSTRAINT fk_frequencia_aluno      FOREIGN KEY (id_aluno)              REFERENCES pessoa            (id_pessoa),
+    CONSTRAINT fk_frequencia_calendario FOREIGN KEY (id_calendario_escolar) REFERENCES calendario_escolar (id_calendario_escolar)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Avaliação: prova ou trabalho aplicado em uma disciplina em um período letivo.
+-- O campo 'dia' registra a data da avaliação; 'materia' registra o conteúdo avaliado.
+CREATE TABLE IF NOT EXISTS avaliacao (
+    id_avaliacao            BIGINT      NOT NULL AUTO_INCREMENT,
+    id_disciplina           BIGINT      NOT NULL,
+    id_calendario_escolar   BIGINT,             -- nullable: avaliação pode ser criada antes do calendário
+    materia                 VARCHAR(255),
+    dia                     VARCHAR(255),
+    created_at              DATETIME    NOT NULL DEFAULT NOW(),
+    updated_at              DATETIME    NOT NULL DEFAULT NOW(),
+    deleted_at              DATETIME    NULL,
+    ativo                   BOOLEAN     NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (id_avaliacao),
+    CONSTRAINT fk_avaliacao_disciplina   FOREIGN KEY (id_disciplina)         REFERENCES disciplina         (id_disciplina),
+    CONSTRAINT fk_avaliacao_calendario   FOREIGN KEY (id_calendario_escolar) REFERENCES calendario_escolar (id_calendario_escolar)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Nota do aluno em uma avaliação específica.
+-- A nota é um FLOAT para suportar casas decimais (ex: 7.5, 8.3).
+CREATE TABLE IF NOT EXISTS aluno_avaliacao (
+    id_aluno_avaliacao  BIGINT      NOT NULL AUTO_INCREMENT,
+    id_aluno            BIGINT      NOT NULL,   -- FK para pessoa (tipo ALUNO)
+    id_avaliacao        BIGINT      NOT NULL,
+    nota                FLOAT,
+    obs                 VARCHAR(255),
+    created_at          DATETIME    NOT NULL DEFAULT NOW(),
+    updated_at          DATETIME    NOT NULL DEFAULT NOW(),
+    deleted_at          DATETIME    NULL,
+    ativo               BOOLEAN     NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (id_aluno_avaliacao),
+    CONSTRAINT fk_aluno_avaliacao_aluno     FOREIGN KEY (id_aluno)     REFERENCES pessoa    (id_pessoa),
+    CONSTRAINT fk_aluno_avaliacao_avaliacao FOREIGN KEY (id_avaliacao) REFERENCES avaliacao (id_avaliacao)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/main/resources/db/migration/V7__create_auth_tables.sql
+++ b/src/main/resources/db/migration/V7__create_auth_tables.sql
@@ -1,0 +1,21 @@
+-- =============================================================================
+-- V7 — Tabela de autenticação (Users)
+-- Separada do módulo Pessoa intencionalmente: isola a autenticação do domínio
+-- pedagógico. Um User pode existir sem um Pessoa vinculado (ex: admin técnico).
+--
+-- O campo 'role' armazena o enum Role como STRING:
+--   ADMINISTRADOR, DIRETOR, COORDENADOR, PROFESSOR, RESPONSAVEL, ALUNO
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS users (
+    id_users    BIGINT          NOT NULL AUTO_INCREMENT,
+    nome        VARCHAR(255),
+    email       VARCHAR(255),
+    senha       VARCHAR(255),
+    role        VARCHAR(50),    -- enum Role armazenado como String
+    created_at  DATETIME        NOT NULL DEFAULT NOW(),
+    updated_at  DATETIME        NOT NULL DEFAULT NOW(),
+    deleted_at  DATETIME        NULL,
+    ativo       BOOLEAN         NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (id_users)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
Resumo:

pom.xml — adicionadas 2 dependências:

flyway-core — núcleo do Flyway
flyway-mysql — obrigatório para MySQL no Flyway 9+
Migrations criadas em src/main/resources/db/migration/:

Arquivo	Tabelas
V1__create_pessoa_tables.sql	tipo_pessoa, pessoa, contato, contato_pessoa, endereco, endereco_pessoa, pessoa_responsavel
V2__create_instituicao_tables.sql	ensino, grau, serie, turno, instituicao_ensino, curso
V3__create_turma_tables.sql	turma, componente_curricular, disciplina
V4__create_classe_turma_tables.sql	classe, aluno_turma
V5__create_calendario_tables.sql	ano_calendario, mes, periodo, calendario_escolar
V6__create_frequencia_avaliacao_tables.sql	aluno_frequencia, avaliacao, aluno_avaliacao
V7__create_auth_tables.sql	users
application-local.properties atualizado:

ddl-auto=none (Flyway gerencia o schema)
flyway.enabled=true, flyway.baseline-on-migrate=true (seguro para banco existente)