### PR TITLE
Criado - shared/dto/ApiResponse.java  record com ok(data), ok(data, message) e error(message)

### DIFF
--- a/src/main/java/com/diario/de/classe/modules/auth/AuthController.java
+++ b/src/main/java/com/diario/de/classe/modules/auth/AuthController.java
@@ -1,6 +1,7 @@
 package com.diario.de.classe.modules.auth;
 
 import com.diario.de.classe.modules.auth.dto.UserMeResponse;
+import com.diario.de.classe.shared.dto.ApiResponse;
 import com.diario.de.classe.shared.security.JwtService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -13,13 +14,13 @@ import org.springframework.web.bind.annotation.*;
  * Controller de autenticação: registro, login, logout e dados do usuário logado.
  *
  * Rotas públicas (liberadas no SecurityConfig):
- *   POST /auth/register
- *   POST /auth/login
- *   POST /auth/logout
- *   GET  /auth/me
+ *   POST /v1/auth/register
+ *   POST /v1/auth/login
+ *   POST /v1/auth/logout
+ *   GET  /v1/auth/me
  */
 @RestController
-@RequestMapping("/auth")
+@RequestMapping("/v1/auth")
 public class AuthController {
 
     private final UserRepository userRepository;
@@ -34,14 +35,16 @@ public class AuthController {
 
     /**
      * Registra um novo usuário, codificando a senha antes de persistir.
+     * A entidade User não é exposta diretamente — retorna apenas confirmação.
      *
      * @param user Dados do usuário (nome, email, senha, role)
-     * @return Usuário persistido (sem a senha em texto claro — TODO: usar DTO de resposta)
+     * @return Confirmação de registro sem expor dados sensíveis
      */
     @PostMapping("/register")
-    public User register(@RequestBody User user) {
+    public ResponseEntity<ApiResponse<Void>> register(@RequestBody User user) {
         user.setSenha(passwordEncoder.encode(user.getSenha()));
-        return userRepository.save(user);
+        userRepository.save(user);
+        return ResponseEntity.ok(ApiResponse.ok(null, "Usuário registrado com sucesso"));
     }
 
     /**
@@ -54,7 +57,7 @@ public class AuthController {
      * @param response Resposta HTTP onde o cookie será adicionado
      */
     @PostMapping("/login")
-    public ResponseEntity<Void> login(@RequestBody User user, HttpServletResponse response) {
+    public ResponseEntity<ApiResponse<Void>> login(@RequestBody User user, HttpServletResponse response) {
         var userFromDb = userRepository.findByEmail(user.getEmail())
                 .orElseThrow(() -> new RuntimeException("Usuário não encontrado"));
 
@@ -72,14 +75,14 @@ public class AuthController {
 
         response.addCookie(cookie);
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.ok(null, "Login realizado com sucesso"));
     }
 
     /**
      * Encerra a sessão do usuário limpando o cookie de autenticação.
      */
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(HttpServletResponse response) {
+    public ResponseEntity<ApiResponse<Void>> logout(HttpServletResponse response) {
         Cookie cookie = new Cookie("auth_token", null);
         cookie.setHttpOnly(true);
         cookie.setPath("/");
@@ -87,7 +90,7 @@ public class AuthController {
 
         response.addCookie(cookie);
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.ok(null, "Logout realizado com sucesso"));
     }
 
     /**
@@ -97,7 +100,7 @@ public class AuthController {
      * @return Dados básicos do usuário (id, email, nome, role)
      */
     @GetMapping("/me")
-    public UserMeResponse me(HttpServletRequest request) {
+    public ResponseEntity<ApiResponse<UserMeResponse>> me(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
         if (cookies == null) throw new RuntimeException("Não autenticado");
 
@@ -118,6 +121,8 @@ public class AuthController {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new RuntimeException("Usuário não encontrado"));
 
-        return new UserMeResponse(user.getIdUsers(), user.getEmail(), user.getNome(), user.getRole());
+        return ResponseEntity.ok(ApiResponse.ok(
+                new UserMeResponse(user.getIdUsers(), user.getEmail(), user.getNome(), user.getRole())
+        ));
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/avaliacao/AlunoAvaliacaoController.java
+++ b/src/main/java/com/diario/de/classe/modules/avaliacao/AlunoAvaliacaoController.java
@@ -1,6 +1,7 @@
 package com.diario.de.classe.modules.avaliacao;
 
 import com.diario.de.classe.modules.avaliacao.dto.AlunoAvaliacaoDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
@@ -22,43 +23,43 @@ public class AlunoAvaliacaoController {
     @Operation(summary = "Listar todas as notas")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
     @GetMapping
-    public ResponseEntity<List<AlunoAvaliacaoDTO>> listar() {
-        return ResponseEntity.ok(service.buscarTodos().stream().map(AlunoAvaliacaoDTO::new).toList());
+    public ResponseEntity<ApiResponse<List<AlunoAvaliacaoDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos().stream().map(AlunoAvaliacaoDTO::new).toList()));
     }
 
     @Operation(summary = "Buscar nota por ID")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
     @GetMapping("/{id}")
-    public ResponseEntity<AlunoAvaliacaoDTO> buscarPorId(@PathVariable Long id) {
-        return ResponseEntity.ok(new AlunoAvaliacaoDTO(service.buscarPorId(id)));
+    public ResponseEntity<ApiResponse<AlunoAvaliacaoDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(new AlunoAvaliacaoDTO(service.buscarPorId(id))));
     }
 
     @Operation(summary = "Registrar nota de aluno")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'PROFESSOR')")
     @PostMapping
-    public ResponseEntity<AlunoAvaliacaoDTO> criar(@RequestBody AlunoAvaliacaoDTO dto) {
+    public ResponseEntity<ApiResponse<AlunoAvaliacaoDTO>> criar(@RequestBody AlunoAvaliacaoDTO dto) {
         AlunoAvaliacao entity = new AlunoAvaliacao();
         entity.setNota(dto.getNota());
         entity.setObs(dto.getObs());
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(new AlunoAvaliacaoDTO(service.criar(entity, dto.getIdAluno(), dto.getIdAvaliacao())));
+                .body(ApiResponse.ok(new AlunoAvaliacaoDTO(service.criar(entity, dto.getIdAluno(), dto.getIdAvaliacao())), "Nota criada com sucesso"));
     }
 
     @Operation(summary = "Atualizar nota de aluno")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'PROFESSOR')")
     @PutMapping("/{id}")
-    public ResponseEntity<AlunoAvaliacaoDTO> atualizar(@PathVariable Long id, @RequestBody AlunoAvaliacaoDTO dto) {
+    public ResponseEntity<ApiResponse<AlunoAvaliacaoDTO>> atualizar(@PathVariable Long id, @RequestBody AlunoAvaliacaoDTO dto) {
         AlunoAvaliacao dados = new AlunoAvaliacao();
         dados.setNota(dto.getNota());
         dados.setObs(dto.getObs());
-        return ResponseEntity.ok(new AlunoAvaliacaoDTO(service.atualizar(id, dados, dto.getIdAluno(), dto.getIdAvaliacao())));
+        return ResponseEntity.ok(ApiResponse.ok(new AlunoAvaliacaoDTO(service.atualizar(id, dados, dto.getIdAluno(), dto.getIdAvaliacao()))));
     }
 
     @Operation(summary = "Excluir nota")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
         service.deletar(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.ok(null, "Excluído com sucesso"));
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/avaliacao/AvaliacaoController.java
+++ b/src/main/java/com/diario/de/classe/modules/avaliacao/AvaliacaoController.java
@@ -1,6 +1,7 @@
 package com.diario.de.classe.modules.avaliacao;
 
 import com.diario.de.classe.modules.avaliacao.dto.AvaliacaoDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
@@ -22,43 +23,43 @@ public class AvaliacaoController {
     @Operation(summary = "Listar todas as avaliações")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
     @GetMapping
-    public ResponseEntity<List<AvaliacaoDTO>> listar() {
-        return ResponseEntity.ok(service.buscarTodos().stream().map(AvaliacaoDTO::new).toList());
+    public ResponseEntity<ApiResponse<List<AvaliacaoDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos().stream().map(AvaliacaoDTO::new).toList()));
     }
 
     @Operation(summary = "Buscar avaliação por ID")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
     @GetMapping("/{id}")
-    public ResponseEntity<AvaliacaoDTO> buscarPorId(@PathVariable Long id) {
-        return ResponseEntity.ok(new AvaliacaoDTO(service.buscarPorId(id)));
+    public ResponseEntity<ApiResponse<AvaliacaoDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(new AvaliacaoDTO(service.buscarPorId(id))));
     }
 
     @Operation(summary = "Criar avaliação")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
     @PostMapping
-    public ResponseEntity<AvaliacaoDTO> criar(@RequestBody AvaliacaoDTO dto) {
+    public ResponseEntity<ApiResponse<AvaliacaoDTO>> criar(@RequestBody AvaliacaoDTO dto) {
         Avaliacao entity = new Avaliacao();
         entity.setMateria(dto.getMateria());
         entity.setDia(dto.getDia());
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(new AvaliacaoDTO(service.criar(entity, dto.getIdDisciplina(), dto.getIdCalendarioEscolar())));
+                .body(ApiResponse.ok(new AvaliacaoDTO(service.criar(entity, dto.getIdDisciplina(), dto.getIdCalendarioEscolar())), "Avaliação criada com sucesso"));
     }
 
     @Operation(summary = "Atualizar avaliação")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
     @PutMapping("/{id}")
-    public ResponseEntity<AvaliacaoDTO> atualizar(@PathVariable Long id, @RequestBody AvaliacaoDTO dto) {
+    public ResponseEntity<ApiResponse<AvaliacaoDTO>> atualizar(@PathVariable Long id, @RequestBody AvaliacaoDTO dto) {
         Avaliacao dados = new Avaliacao();
         dados.setMateria(dto.getMateria());
         dados.setDia(dto.getDia());
-        return ResponseEntity.ok(new AvaliacaoDTO(service.atualizar(id, dados, dto.getIdDisciplina(), dto.getIdCalendarioEscolar())));
+        return ResponseEntity.ok(ApiResponse.ok(new AvaliacaoDTO(service.atualizar(id, dados, dto.getIdDisciplina(), dto.getIdCalendarioEscolar()))));
     }
 
     @Operation(summary = "Excluir avaliação")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
         service.deletar(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.ok(null, "Excluído com sucesso"));
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/calendario/AnoCalendarioController.java
+++ b/src/main/java/com/diario/de/classe/modules/calendario/AnoCalendarioController.java
@@ -1,6 +1,7 @@
 package com.diario.de.classe.modules.calendario;
 
 import com.diario.de.classe.modules.calendario.dto.AnoCalendarioDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.BeanUtils;
@@ -23,40 +24,40 @@ public class AnoCalendarioController {
     @Operation(summary = "Listar Todos os anos")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping
-    public ResponseEntity<List<AnoCalendarioDTO>> listar() {
-        return ResponseEntity.ok(service.buscarTodos().stream().map(AnoCalendarioDTO::new).toList());
+    public ResponseEntity<ApiResponse<List<AnoCalendarioDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos().stream().map(AnoCalendarioDTO::new).toList()));
     }
 
     @Operation(summary = "Buscar ano por ID")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping("/{id}")
-    public ResponseEntity<AnoCalendarioDTO> buscarPorId(@PathVariable Long id) {
-        return ResponseEntity.ok(new AnoCalendarioDTO(service.buscarPorId(id)));
+    public ResponseEntity<ApiResponse<AnoCalendarioDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(new AnoCalendarioDTO(service.buscarPorId(id))));
     }
 
     @Operation(summary = "Criar ano calendário")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @PostMapping
-    public ResponseEntity<AnoCalendarioDTO> criar(@RequestBody AnoCalendarioDTO dto) {
+    public ResponseEntity<ApiResponse<AnoCalendarioDTO>> criar(@RequestBody AnoCalendarioDTO dto) {
         AnoCalendario entity = new AnoCalendario();
         BeanUtils.copyProperties(dto, entity, "idAnoCalendario");
-        return ResponseEntity.status(HttpStatus.CREATED).body(new AnoCalendarioDTO(service.criar(entity)));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(new AnoCalendarioDTO(service.criar(entity)), "Ano calendário criado com sucesso"));
     }
 
     @Operation(summary = "Atualizar ano calendário")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @PutMapping("/{id}")
-    public ResponseEntity<AnoCalendarioDTO> atualizar(@PathVariable Long id, @RequestBody AnoCalendarioDTO dto) {
+    public ResponseEntity<ApiResponse<AnoCalendarioDTO>> atualizar(@PathVariable Long id, @RequestBody AnoCalendarioDTO dto) {
         AnoCalendario dados = new AnoCalendario();
         BeanUtils.copyProperties(dto, dados, "idAnoCalendario");
-        return ResponseEntity.ok(new AnoCalendarioDTO(service.atualizar(id, dados)));
+        return ResponseEntity.ok(ApiResponse.ok(new AnoCalendarioDTO(service.atualizar(id, dados))));
     }
 
     @Operation(summary = "Excluir ano calendário")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
         service.deletar(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.ok(null, "Excluído com sucesso"));
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/calendario/CalendarioEscolarController.java
+++ b/src/main/java/com/diario/de/classe/modules/calendario/CalendarioEscolarController.java
@@ -1,6 +1,7 @@
 package com.diario.de.classe.modules.calendario;
 
 import com.diario.de.classe.modules.calendario.dto.CalendarioEscolarDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.BeanUtils;
@@ -23,46 +24,46 @@ public class CalendarioEscolarController {
     @Operation(summary = "Listar todos os calendários")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
     @GetMapping
-    public ResponseEntity<List<CalendarioEscolarDTO>> listar() {
-        return ResponseEntity.ok(service.buscarTodos().stream().map(CalendarioEscolarDTO::new).toList());
+    public ResponseEntity<ApiResponse<List<CalendarioEscolarDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos().stream().map(CalendarioEscolarDTO::new).toList()));
     }
 
     @Operation(summary = "Buscar calendário por ID")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
     @GetMapping("/{id}")
-    public ResponseEntity<CalendarioEscolarDTO> buscarPorId(@PathVariable Long id) {
-        return ResponseEntity.ok(new CalendarioEscolarDTO(service.buscarPorId(id)));
+    public ResponseEntity<ApiResponse<CalendarioEscolarDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(new CalendarioEscolarDTO(service.buscarPorId(id))));
     }
 
     @Operation(summary = "Criar calendário escolar")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @PostMapping
-    public ResponseEntity<CalendarioEscolarDTO> criar(@RequestBody CalendarioEscolarDTO dto) {
+    public ResponseEntity<ApiResponse<CalendarioEscolarDTO>> criar(@RequestBody CalendarioEscolarDTO dto) {
         CalendarioEscolar entity = new CalendarioEscolar();
         BeanUtils.copyProperties(dto, entity, "idCalendarioEscolar", "mes", "anoCalendario", "periodo", "classe");
         entity.setDiasLetivos(dto.getDiasLetivos());
         entity.setDiasAvaliacoes(dto.getDiasAvaliacoes());
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(new CalendarioEscolarDTO(service.criar(entity, dto.getIdMes(), dto.getIdAnoCalendario(),
-                        dto.getIdPeriodo(), dto.getIdClasse())));
+                .body(ApiResponse.ok(new CalendarioEscolarDTO(service.criar(entity, dto.getIdMes(), dto.getIdAnoCalendario(),
+                        dto.getIdPeriodo(), dto.getIdClasse())), "Calendário escolar criado com sucesso"));
     }
 
     @Operation(summary = "Atualizar calendário escolar")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @PutMapping("/{id}")
-    public ResponseEntity<CalendarioEscolarDTO> atualizar(@PathVariable Long id, @RequestBody CalendarioEscolarDTO dto) {
+    public ResponseEntity<ApiResponse<CalendarioEscolarDTO>> atualizar(@PathVariable Long id, @RequestBody CalendarioEscolarDTO dto) {
         CalendarioEscolar dados = new CalendarioEscolar();
         dados.setDiasLetivos(dto.getDiasLetivos());
         dados.setDiasAvaliacoes(dto.getDiasAvaliacoes());
-        return ResponseEntity.ok(new CalendarioEscolarDTO(service.atualizar(id, dados, dto.getIdMes(),
-                dto.getIdAnoCalendario(), dto.getIdPeriodo(), dto.getIdClasse())));
+        return ResponseEntity.ok(ApiResponse.ok(new CalendarioEscolarDTO(service.atualizar(id, dados, dto.getIdMes(),
+                dto.getIdAnoCalendario(), dto.getIdPeriodo(), dto.getIdClasse()))));
     }
 
     @Operation(summary = "Excluir calendário escolar")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
         service.deletar(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.ok(null, "Excluído com sucesso"));
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/calendario/MesController.java
+++ b/src/main/java/com/diario/de/classe/modules/calendario/MesController.java
@@ -1,6 +1,7 @@
 package com.diario.de.classe.modules.calendario;
 
 import com.diario.de.classe.modules.calendario.dto.MesDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.BeanUtils;
@@ -23,40 +24,40 @@ public class MesController {
     @Operation(summary = "Listar todos os meses")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping
-    public ResponseEntity<List<MesDTO>> listar() {
-        return ResponseEntity.ok(service.buscarTodos().stream().map(MesDTO::new).toList());
+    public ResponseEntity<ApiResponse<List<MesDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos().stream().map(MesDTO::new).toList()));
     }
 
     @Operation(summary = "Buscar mês por ID")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping("/{id}")
-    public ResponseEntity<MesDTO> buscarPorId(@PathVariable Long id) {
-        return ResponseEntity.ok(new MesDTO(service.buscarPorId(id)));
+    public ResponseEntity<ApiResponse<MesDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(new MesDTO(service.buscarPorId(id))));
     }
 
     @Operation(summary = "Criar mês")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @PostMapping
-    public ResponseEntity<MesDTO> criar(@RequestBody MesDTO dto) {
+    public ResponseEntity<ApiResponse<MesDTO>> criar(@RequestBody MesDTO dto) {
         Mes entity = new Mes();
         BeanUtils.copyProperties(dto, entity, "idMes");
-        return ResponseEntity.status(HttpStatus.CREATED).body(new MesDTO(service.criar(entity)));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(new MesDTO(service.criar(entity)), "Mês criado com sucesso"));
     }
 
     @Operation(summary = "Atualizar mês")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @PutMapping("/{id}")
-    public ResponseEntity<MesDTO> atualizar(@PathVariable Long id, @RequestBody MesDTO dto) {
+    public ResponseEntity<ApiResponse<MesDTO>> atualizar(@PathVariable Long id, @RequestBody MesDTO dto) {
         Mes dados = new Mes();
         BeanUtils.copyProperties(dto, dados, "idMes");
-        return ResponseEntity.ok(new MesDTO(service.atualizar(id, dados)));
+        return ResponseEntity.ok(ApiResponse.ok(new MesDTO(service.atualizar(id, dados))));
     }
 
     @Operation(summary = "Excluir mês")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
         service.deletar(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.ok(null, "Excluído com sucesso"));
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/calendario/PeriodoController.java
+++ b/src/main/java/com/diario/de/classe/modules/calendario/PeriodoController.java
@@ -1,6 +1,7 @@
 package com.diario.de.classe.modules.calendario;
 
 import com.diario.de.classe.modules.calendario.dto.PeriodoDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.BeanUtils;
@@ -23,40 +24,40 @@ public class PeriodoController {
     @Operation(summary = "Listar todos os períodos")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping
-    public ResponseEntity<List<PeriodoDTO>> listar() {
-        return ResponseEntity.ok(service.buscarTodos().stream().map(PeriodoDTO::new).toList());
+    public ResponseEntity<ApiResponse<List<PeriodoDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos().stream().map(PeriodoDTO::new).toList()));
     }
 
     @Operation(summary = "Buscar período por ID")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping("/{id}")
-    public ResponseEntity<PeriodoDTO> buscarPorId(@PathVariable Long id) {
-        return ResponseEntity.ok(new PeriodoDTO(service.buscarPorId(id)));
+    public ResponseEntity<ApiResponse<PeriodoDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(new PeriodoDTO(service.buscarPorId(id))));
     }
 
     @Operation(summary = "Criar período")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @PostMapping
-    public ResponseEntity<PeriodoDTO> criar(@RequestBody PeriodoDTO dto) {
+    public ResponseEntity<ApiResponse<PeriodoDTO>> criar(@RequestBody PeriodoDTO dto) {
         Periodo entity = new Periodo();
         BeanUtils.copyProperties(dto, entity, "idPeriodo");
-        return ResponseEntity.status(HttpStatus.CREATED).body(new PeriodoDTO(service.criar(entity)));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(new PeriodoDTO(service.criar(entity)), "Período criado com sucesso"));
     }
 
     @Operation(summary = "Atualizar período")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @PutMapping("/{id}")
-    public ResponseEntity<PeriodoDTO> atualizar(@PathVariable Long id, @RequestBody PeriodoDTO dto) {
+    public ResponseEntity<ApiResponse<PeriodoDTO>> atualizar(@PathVariable Long id, @RequestBody PeriodoDTO dto) {
         Periodo dados = new Periodo();
         BeanUtils.copyProperties(dto, dados, "idPeriodo");
-        return ResponseEntity.ok(new PeriodoDTO(service.atualizar(id, dados)));
+        return ResponseEntity.ok(ApiResponse.ok(new PeriodoDTO(service.atualizar(id, dados))));
     }
 
     @Operation(summary = "Excluir período")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
         service.deletar(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.ok(null, "Excluído com sucesso"));
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/frequencia/AlunoFrequenciaController.java
+++ b/src/main/java/com/diario/de/classe/modules/frequencia/AlunoFrequenciaController.java
@@ -1,6 +1,7 @@
 package com.diario.de.classe.modules.frequencia;
 
 import com.diario.de.classe.modules.frequencia.dto.AlunoFrequenciaDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
@@ -22,41 +23,41 @@ public class AlunoFrequenciaController {
     @Operation(summary = "Listar todas as frequências")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
     @GetMapping
-    public ResponseEntity<List<AlunoFrequenciaDTO>> listar() {
-        return ResponseEntity.ok(service.buscarTodos().stream().map(AlunoFrequenciaDTO::new).toList());
+    public ResponseEntity<ApiResponse<List<AlunoFrequenciaDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos().stream().map(AlunoFrequenciaDTO::new).toList()));
     }
 
     @Operation(summary = "Buscar frequência por ID")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
     @GetMapping("/{id}")
-    public ResponseEntity<AlunoFrequenciaDTO> buscarPorId(@PathVariable Long id) {
-        return ResponseEntity.ok(new AlunoFrequenciaDTO(service.buscarPorId(id)));
+    public ResponseEntity<ApiResponse<AlunoFrequenciaDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(new AlunoFrequenciaDTO(service.buscarPorId(id))));
     }
 
     @Operation(summary = "Registrar frequência de aluno")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'PROFESSOR')")
     @PostMapping
-    public ResponseEntity<AlunoFrequenciaDTO> criar(@RequestBody AlunoFrequenciaDTO dto) {
+    public ResponseEntity<ApiResponse<AlunoFrequenciaDTO>> criar(@RequestBody AlunoFrequenciaDTO dto) {
         AlunoFrequencia entity = new AlunoFrequencia();
         entity.setFaltas(dto.getFaltas());
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(new AlunoFrequenciaDTO(service.criar(entity, dto.getIdAluno(), dto.getIdCalendarioEscolar())));
+                .body(ApiResponse.ok(new AlunoFrequenciaDTO(service.criar(entity, dto.getIdAluno(), dto.getIdCalendarioEscolar())), "Frequência criada com sucesso"));
     }
 
     @Operation(summary = "Atualizar frequência de aluno")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'PROFESSOR')")
     @PutMapping("/{id}")
-    public ResponseEntity<AlunoFrequenciaDTO> atualizar(@PathVariable Long id, @RequestBody AlunoFrequenciaDTO dto) {
+    public ResponseEntity<ApiResponse<AlunoFrequenciaDTO>> atualizar(@PathVariable Long id, @RequestBody AlunoFrequenciaDTO dto) {
         AlunoFrequencia dados = new AlunoFrequencia();
         dados.setFaltas(dto.getFaltas());
-        return ResponseEntity.ok(new AlunoFrequenciaDTO(service.atualizar(id, dados, dto.getIdAluno(), dto.getIdCalendarioEscolar())));
+        return ResponseEntity.ok(ApiResponse.ok(new AlunoFrequenciaDTO(service.atualizar(id, dados, dto.getIdAluno(), dto.getIdCalendarioEscolar()))));
     }
 
     @Operation(summary = "Excluir frequência")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
         service.deletar(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.ok(null, "Excluído com sucesso"));
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/instituicao/CursoController.java
+++ b/src/main/java/com/diario/de/classe/modules/instituicao/CursoController.java
@@ -1,6 +1,7 @@
 package com.diario.de.classe.modules.instituicao;
 
 import com.diario.de.classe.modules.instituicao.dto.CursoDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
@@ -22,39 +23,39 @@ public class CursoController {
     @Operation(summary = "Listar todos os cursos")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping
-    public ResponseEntity<List<CursoDTO>> listar() {
-        return ResponseEntity.ok(service.buscarTodos().stream().map(CursoDTO::new).toList());
+    public ResponseEntity<ApiResponse<List<CursoDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos().stream().map(CursoDTO::new).toList()));
     }
 
     @Operation(summary = "Buscar curso por ID")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping("/{id}")
-    public ResponseEntity<CursoDTO> buscarPorId(@PathVariable Long id) {
-        return ResponseEntity.ok(new CursoDTO(service.buscarPorId(id)));
+    public ResponseEntity<ApiResponse<CursoDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(new CursoDTO(service.buscarPorId(id))));
     }
 
     @Operation(summary = "Criar novo curso")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @PostMapping
-    public ResponseEntity<CursoDTO> criar(@RequestBody CursoDTO dto) {
+    public ResponseEntity<ApiResponse<CursoDTO>> criar(@RequestBody CursoDTO dto) {
         Curso entity = new Curso();
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(new CursoDTO(service.criar(entity, dto.getIdEnsino(), dto.getIdGrau(), dto.getIdSerie())));
+                .body(ApiResponse.ok(new CursoDTO(service.criar(entity, dto.getIdEnsino(), dto.getIdGrau(), dto.getIdSerie())), "Curso criado com sucesso"));
     }
 
     @Operation(summary = "Atualizar curso")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @PutMapping("/{id}")
-    public ResponseEntity<CursoDTO> atualizar(@PathVariable Long id, @RequestBody CursoDTO dto) {
+    public ResponseEntity<ApiResponse<CursoDTO>> atualizar(@PathVariable Long id, @RequestBody CursoDTO dto) {
         Curso dados = new Curso();
-        return ResponseEntity.ok(new CursoDTO(service.atualizar(id, dados, dto.getIdEnsino(), dto.getIdGrau(), dto.getIdSerie())));
+        return ResponseEntity.ok(ApiResponse.ok(new CursoDTO(service.atualizar(id, dados, dto.getIdEnsino(), dto.getIdGrau(), dto.getIdSerie()))));
     }
 
     @Operation(summary = "Excluir curso")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
         service.deletar(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.ok(null, "Excluído com sucesso"));
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/instituicao/EnsinoController.java
+++ b/src/main/java/com/diario/de/classe/modules/instituicao/EnsinoController.java
@@ -1,6 +1,7 @@
 package com.diario.de.classe.modules.instituicao;
 
 import com.diario.de.classe.modules.instituicao.dto.EnsinoDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.BeanUtils;
@@ -21,40 +22,40 @@ public class EnsinoController {
     @Operation(summary = "Listar todos")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping
-    public ResponseEntity<List<EnsinoDTO>> listar() {
-        return ResponseEntity.ok(service.buscarTodos().stream().map(EnsinoDTO::new).toList());
+    public ResponseEntity<ApiResponse<List<EnsinoDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos().stream().map(EnsinoDTO::new).toList()));
     }
 
     @Operation(summary = "Buscar por ID")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping("/{id}")
-    public ResponseEntity<EnsinoDTO> buscarPorId(@PathVariable Long id) {
-        return ResponseEntity.ok(new EnsinoDTO(service.buscarPorId(id)));
+    public ResponseEntity<ApiResponse<EnsinoDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(new EnsinoDTO(service.buscarPorId(id))));
     }
 
     @Operation(summary = "Criar")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @PostMapping
-    public ResponseEntity<EnsinoDTO> criar(@RequestBody EnsinoDTO dto) {
+    public ResponseEntity<ApiResponse<EnsinoDTO>> criar(@RequestBody EnsinoDTO dto) {
         Ensino entity = new Ensino();
         BeanUtils.copyProperties(dto, entity, "idEnsino");
-        return ResponseEntity.status(HttpStatus.CREATED).body(new EnsinoDTO(service.criar(entity)));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(new EnsinoDTO(service.criar(entity)), "Ensino criado com sucesso"));
     }
 
     @Operation(summary = "Atualizar")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @PutMapping("/{id}")
-    public ResponseEntity<EnsinoDTO> atualizar(@PathVariable Long id, @RequestBody EnsinoDTO dto) {
+    public ResponseEntity<ApiResponse<EnsinoDTO>> atualizar(@PathVariable Long id, @RequestBody EnsinoDTO dto) {
         Ensino dados = new Ensino();
         BeanUtils.copyProperties(dto, dados, "idEnsino");
-        return ResponseEntity.ok(new EnsinoDTO(service.atualizar(id, dados)));
+        return ResponseEntity.ok(ApiResponse.ok(new EnsinoDTO(service.atualizar(id, dados))));
     }
 
     @Operation(summary = "Excluir")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
         service.deletar(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.ok(null, "Excluído com sucesso"));
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/instituicao/GrauController.java
+++ b/src/main/java/com/diario/de/classe/modules/instituicao/GrauController.java
@@ -1,6 +1,7 @@
 package com.diario.de.classe.modules.instituicao;
 
 import com.diario.de.classe.modules.instituicao.dto.GrauDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.BeanUtils;
@@ -21,40 +22,40 @@ public class GrauController {
     @Operation(summary = "Listar todos")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping
-    public ResponseEntity<List<GrauDTO>> listar() {
-        return ResponseEntity.ok(service.buscarTodos().stream().map(GrauDTO::new).toList());
+    public ResponseEntity<ApiResponse<List<GrauDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos().stream().map(GrauDTO::new).toList()));
     }
 
     @Operation(summary = "Buscar por ID")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping("/{id}")
-    public ResponseEntity<GrauDTO> buscarPorId(@PathVariable Long id) {
-        return ResponseEntity.ok(new GrauDTO(service.buscarPorId(id)));
+    public ResponseEntity<ApiResponse<GrauDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(new GrauDTO(service.buscarPorId(id))));
     }
 
     @Operation(summary = "Criar")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @PostMapping
-    public ResponseEntity<GrauDTO> criar(@RequestBody GrauDTO dto) {
+    public ResponseEntity<ApiResponse<GrauDTO>> criar(@RequestBody GrauDTO dto) {
         Grau entity = new Grau();
         BeanUtils.copyProperties(dto, entity, "idGrau");
-        return ResponseEntity.status(HttpStatus.CREATED).body(new GrauDTO(service.criar(entity)));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(new GrauDTO(service.criar(entity)), "Grau criado com sucesso"));
     }
 
     @Operation(summary = "Atualizar")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @PutMapping("/{id}")
-    public ResponseEntity<GrauDTO> atualizar(@PathVariable Long id, @RequestBody GrauDTO dto) {
+    public ResponseEntity<ApiResponse<GrauDTO>> atualizar(@PathVariable Long id, @RequestBody GrauDTO dto) {
         Grau dados = new Grau();
         BeanUtils.copyProperties(dto, dados, "idGrau");
-        return ResponseEntity.ok(new GrauDTO(service.atualizar(id, dados)));
+        return ResponseEntity.ok(ApiResponse.ok(new GrauDTO(service.atualizar(id, dados))));
     }
 
     @Operation(summary = "Excluir")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
         service.deletar(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.ok(null, "Excluído com sucesso"));
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/instituicao/InstituicaoEnsinoController.java
+++ b/src/main/java/com/diario/de/classe/modules/instituicao/InstituicaoEnsinoController.java
@@ -1,6 +1,7 @@
 package com.diario.de.classe.modules.instituicao;
 
 import com.diario.de.classe.modules.instituicao.dto.InstituicaoEnsinoDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.BeanUtils;
@@ -21,40 +22,40 @@ public class InstituicaoEnsinoController {
     @Operation(summary = "Listar todos")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping
-    public ResponseEntity<List<InstituicaoEnsinoDTO>> listar() {
-        return ResponseEntity.ok(service.buscarTodos().stream().map(InstituicaoEnsinoDTO::new).toList());
+    public ResponseEntity<ApiResponse<List<InstituicaoEnsinoDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos().stream().map(InstituicaoEnsinoDTO::new).toList()));
     }
 
     @Operation(summary = "Buscar por ID")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping("/{id}")
-    public ResponseEntity<InstituicaoEnsinoDTO> buscarPorId(@PathVariable Long id) {
-        return ResponseEntity.ok(new InstituicaoEnsinoDTO(service.buscarPorId(id)));
+    public ResponseEntity<ApiResponse<InstituicaoEnsinoDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(new InstituicaoEnsinoDTO(service.buscarPorId(id))));
     }
 
     @Operation(summary = "Criar")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @PostMapping
-    public ResponseEntity<InstituicaoEnsinoDTO> criar(@RequestBody InstituicaoEnsinoDTO dto) {
+    public ResponseEntity<ApiResponse<InstituicaoEnsinoDTO>> criar(@RequestBody InstituicaoEnsinoDTO dto) {
         InstituicaoEnsino entity = new InstituicaoEnsino();
         BeanUtils.copyProperties(dto, entity, "idInstituicaoEnsino");
-        return ResponseEntity.status(HttpStatus.CREATED).body(new InstituicaoEnsinoDTO(service.criar(entity)));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(new InstituicaoEnsinoDTO(service.criar(entity)), "Instituição de ensino criada com sucesso"));
     }
 
     @Operation(summary = "Atualizar")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @PutMapping("/{id}")
-    public ResponseEntity<InstituicaoEnsinoDTO> atualizar(@PathVariable Long id, @RequestBody InstituicaoEnsinoDTO dto) {
+    public ResponseEntity<ApiResponse<InstituicaoEnsinoDTO>> atualizar(@PathVariable Long id, @RequestBody InstituicaoEnsinoDTO dto) {
         InstituicaoEnsino dados = new InstituicaoEnsino();
         BeanUtils.copyProperties(dto, dados, "idInstituicaoEnsino");
-        return ResponseEntity.ok(new InstituicaoEnsinoDTO(service.atualizar(id, dados)));
+        return ResponseEntity.ok(ApiResponse.ok(new InstituicaoEnsinoDTO(service.atualizar(id, dados))));
     }
 
     @Operation(summary = "Excluir")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
         service.deletar(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.ok(null, "Excluído com sucesso"));
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/instituicao/SerieController.java
+++ b/src/main/java/com/diario/de/classe/modules/instituicao/SerieController.java
@@ -1,6 +1,7 @@
 package com.diario.de.classe.modules.instituicao;
 
 import com.diario.de.classe.modules.instituicao.dto.SerieDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.BeanUtils;
@@ -21,40 +22,40 @@ public class SerieController {
     @Operation(summary = "Listar todos")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping
-    public ResponseEntity<List<SerieDTO>> listar() {
-        return ResponseEntity.ok(service.buscarTodos().stream().map(SerieDTO::new).toList());
+    public ResponseEntity<ApiResponse<List<SerieDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos().stream().map(SerieDTO::new).toList()));
     }
 
     @Operation(summary = "Buscar por ID")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping("/{id}")
-    public ResponseEntity<SerieDTO> buscarPorId(@PathVariable Long id) {
-        return ResponseEntity.ok(new SerieDTO(service.buscarPorId(id)));
+    public ResponseEntity<ApiResponse<SerieDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(new SerieDTO(service.buscarPorId(id))));
     }
 
     @Operation(summary = "Criar")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @PostMapping
-    public ResponseEntity<SerieDTO> criar(@RequestBody SerieDTO dto) {
+    public ResponseEntity<ApiResponse<SerieDTO>> criar(@RequestBody SerieDTO dto) {
         Serie entity = new Serie();
         BeanUtils.copyProperties(dto, entity, "idSerie");
-        return ResponseEntity.status(HttpStatus.CREATED).body(new SerieDTO(service.criar(entity)));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(new SerieDTO(service.criar(entity)), "Série criada com sucesso"));
     }
 
     @Operation(summary = "Atualizar")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @PutMapping("/{id}")
-    public ResponseEntity<SerieDTO> atualizar(@PathVariable Long id, @RequestBody SerieDTO dto) {
+    public ResponseEntity<ApiResponse<SerieDTO>> atualizar(@PathVariable Long id, @RequestBody SerieDTO dto) {
         Serie dados = new Serie();
         BeanUtils.copyProperties(dto, dados, "idSerie");
-        return ResponseEntity.ok(new SerieDTO(service.atualizar(id, dados)));
+        return ResponseEntity.ok(ApiResponse.ok(new SerieDTO(service.atualizar(id, dados))));
     }
 
     @Operation(summary = "Excluir")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
         service.deletar(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.ok(null, "Excluído com sucesso"));
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/instituicao/TurnoController.java
+++ b/src/main/java/com/diario/de/classe/modules/instituicao/TurnoController.java
@@ -1,6 +1,7 @@
 package com.diario.de.classe.modules.instituicao;
 
 import com.diario.de.classe.modules.instituicao.dto.TurnoDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.BeanUtils;
@@ -21,40 +22,40 @@ public class TurnoController {
     @Operation(summary = "Listar todos")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping
-    public ResponseEntity<List<TurnoDTO>> listar() {
-        return ResponseEntity.ok(service.buscarTodos().stream().map(TurnoDTO::new).toList());
+    public ResponseEntity<ApiResponse<List<TurnoDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos().stream().map(TurnoDTO::new).toList()));
     }
 
     @Operation(summary = "Buscar por ID")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping("/{id}")
-    public ResponseEntity<TurnoDTO> buscarPorId(@PathVariable Long id) {
-        return ResponseEntity.ok(new TurnoDTO(service.buscarPorId(id)));
+    public ResponseEntity<ApiResponse<TurnoDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(new TurnoDTO(service.buscarPorId(id))));
     }
 
     @Operation(summary = "Criar")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @PostMapping
-    public ResponseEntity<TurnoDTO> criar(@RequestBody TurnoDTO dto) {
+    public ResponseEntity<ApiResponse<TurnoDTO>> criar(@RequestBody TurnoDTO dto) {
         Turno entity = new Turno();
         BeanUtils.copyProperties(dto, entity, "idTurno");
-        return ResponseEntity.status(HttpStatus.CREATED).body(new TurnoDTO(service.criar(entity)));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(new TurnoDTO(service.criar(entity)), "Turno criado com sucesso"));
     }
 
     @Operation(summary = "Atualizar")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @PutMapping("/{id}")
-    public ResponseEntity<TurnoDTO> atualizar(@PathVariable Long id, @RequestBody TurnoDTO dto) {
+    public ResponseEntity<ApiResponse<TurnoDTO>> atualizar(@PathVariable Long id, @RequestBody TurnoDTO dto) {
         Turno dados = new Turno();
         BeanUtils.copyProperties(dto, dados, "idTurno");
-        return ResponseEntity.ok(new TurnoDTO(service.atualizar(id, dados)));
+        return ResponseEntity.ok(ApiResponse.ok(new TurnoDTO(service.atualizar(id, dados))));
     }
 
     @Operation(summary = "Excluir")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
         service.deletar(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.ok(null, "Excluído com sucesso"));
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/pessoa/ContatoController.java
+++ b/src/main/java/com/diario/de/classe/modules/pessoa/ContatoController.java
@@ -1,6 +1,7 @@
 package com.diario.de.classe.modules.pessoa;
 
 import com.diario.de.classe.modules.pessoa.dto.ContatoDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.BeanUtils;
@@ -25,40 +26,40 @@ public class ContatoController {
     @Operation(summary = "Listar todos os contatos")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping
-    public ResponseEntity<List<ContatoDTO>> listar() {
-        return ResponseEntity.ok(service.buscarTodos().stream().map(ContatoDTO::new).toList());
+    public ResponseEntity<ApiResponse<List<ContatoDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos().stream().map(ContatoDTO::new).toList()));
     }
 
     @Operation(summary = "Buscar contato por ID")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping("/{id}")
-    public ResponseEntity<ContatoDTO> buscarPorId(@PathVariable Long id) {
-        return ResponseEntity.ok(new ContatoDTO(service.buscarPorId(id)));
+    public ResponseEntity<ApiResponse<ContatoDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(new ContatoDTO(service.buscarPorId(id))));
     }
 
     @Operation(summary = "Criar novo contato")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @PostMapping
-    public ResponseEntity<ContatoDTO> criar(@RequestBody ContatoDTO dto) {
+    public ResponseEntity<ApiResponse<ContatoDTO>> criar(@RequestBody ContatoDTO dto) {
         Contato entity = new Contato();
         BeanUtils.copyProperties(dto, entity, "idContato");
-        return ResponseEntity.status(HttpStatus.CREATED).body(new ContatoDTO(service.criar(entity)));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(new ContatoDTO(service.criar(entity)), "Contato criado com sucesso"));
     }
 
     @Operation(summary = "Atualizar contato")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @PutMapping("/{id}")
-    public ResponseEntity<ContatoDTO> atualizar(@PathVariable Long id, @RequestBody ContatoDTO dto) {
+    public ResponseEntity<ApiResponse<ContatoDTO>> atualizar(@PathVariable Long id, @RequestBody ContatoDTO dto) {
         Contato dados = new Contato();
         BeanUtils.copyProperties(dto, dados, "idContato");
-        return ResponseEntity.ok(new ContatoDTO(service.atualizar(id, dados)));
+        return ResponseEntity.ok(ApiResponse.ok(new ContatoDTO(service.atualizar(id, dados))));
     }
 
     @Operation(summary = "Excluir contato")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
         service.deletar(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.ok(null, "Excluído com sucesso"));
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/pessoa/ContatoPessoaController.java
+++ b/src/main/java/com/diario/de/classe/modules/pessoa/ContatoPessoaController.java
@@ -1,6 +1,7 @@
 package com.diario.de.classe.modules.pessoa;
 
 import com.diario.de.classe.modules.pessoa.dto.ContatoPessoaDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.BeanUtils;
@@ -25,42 +26,42 @@ public class ContatoPessoaController {
     @Operation(summary = "Listar todas as associações contato-pessoa")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping
-    public ResponseEntity<List<ContatoPessoaDTO>> listar() {
-        return ResponseEntity.ok(service.buscarTodos().stream().map(ContatoPessoaDTO::new).toList());
+    public ResponseEntity<ApiResponse<List<ContatoPessoaDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos().stream().map(ContatoPessoaDTO::new).toList()));
     }
 
     @Operation(summary = "Buscar associação por ID")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping("/{id}")
-    public ResponseEntity<ContatoPessoaDTO> buscarPorId(@PathVariable Long id) {
-        return ResponseEntity.ok(new ContatoPessoaDTO(service.buscarPorId(id)));
+    public ResponseEntity<ApiResponse<ContatoPessoaDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(new ContatoPessoaDTO(service.buscarPorId(id))));
     }
 
     @Operation(summary = "Criar nova associação contato-pessoa")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @PostMapping
-    public ResponseEntity<ContatoPessoaDTO> criar(@RequestBody ContatoPessoaDTO dto) {
+    public ResponseEntity<ApiResponse<ContatoPessoaDTO>> criar(@RequestBody ContatoPessoaDTO dto) {
         ContatoPessoa entity = new ContatoPessoa();
         BeanUtils.copyProperties(dto, entity, "idContatoPessoa", "idPessoa", "idContato");
         entity.setNome(dto.getNome());
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(new ContatoPessoaDTO(service.criar(entity, dto.getIdPessoa(), dto.getIdContato())));
+                .body(ApiResponse.ok(new ContatoPessoaDTO(service.criar(entity, dto.getIdPessoa(), dto.getIdContato())), "Contato da pessoa criado com sucesso"));
     }
 
     @Operation(summary = "Atualizar associação contato-pessoa")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @PutMapping("/{id}")
-    public ResponseEntity<ContatoPessoaDTO> atualizar(@PathVariable Long id, @RequestBody ContatoPessoaDTO dto) {
+    public ResponseEntity<ApiResponse<ContatoPessoaDTO>> atualizar(@PathVariable Long id, @RequestBody ContatoPessoaDTO dto) {
         ContatoPessoa dados = new ContatoPessoa();
         dados.setNome(dto.getNome());
-        return ResponseEntity.ok(new ContatoPessoaDTO(service.atualizar(id, dados)));
+        return ResponseEntity.ok(ApiResponse.ok(new ContatoPessoaDTO(service.atualizar(id, dados))));
     }
 
     @Operation(summary = "Excluir associação contato-pessoa")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
         service.deletar(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.ok(null, "Excluído com sucesso"));
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/pessoa/EnderecoController.java
+++ b/src/main/java/com/diario/de/classe/modules/pessoa/EnderecoController.java
@@ -1,6 +1,7 @@
 package com.diario.de.classe.modules.pessoa;
 
 import com.diario.de.classe.modules.pessoa.dto.EnderecoDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.BeanUtils;
@@ -25,40 +26,40 @@ public class EnderecoController {
     @Operation(summary = "Listar todos os endereços")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping
-    public ResponseEntity<List<EnderecoDTO>> listar() {
-        return ResponseEntity.ok(service.buscarTodos().stream().map(EnderecoDTO::new).toList());
+    public ResponseEntity<ApiResponse<List<EnderecoDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos().stream().map(EnderecoDTO::new).toList()));
     }
 
     @Operation(summary = "Buscar endereço por ID")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping("/{id}")
-    public ResponseEntity<EnderecoDTO> buscarPorId(@PathVariable Long id) {
-        return ResponseEntity.ok(new EnderecoDTO(service.buscarPorId(id)));
+    public ResponseEntity<ApiResponse<EnderecoDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(new EnderecoDTO(service.buscarPorId(id))));
     }
 
     @Operation(summary = "Criar novo endereço")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @PostMapping
-    public ResponseEntity<EnderecoDTO> criar(@RequestBody EnderecoDTO dto) {
+    public ResponseEntity<ApiResponse<EnderecoDTO>> criar(@RequestBody EnderecoDTO dto) {
         Endereco entity = new Endereco();
         BeanUtils.copyProperties(dto, entity, "idEndereco");
-        return ResponseEntity.status(HttpStatus.CREATED).body(new EnderecoDTO(service.criar(entity)));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(new EnderecoDTO(service.criar(entity)), "Endereço criado com sucesso"));
     }
 
     @Operation(summary = "Atualizar endereço")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @PutMapping("/{id}")
-    public ResponseEntity<EnderecoDTO> atualizar(@PathVariable Long id, @RequestBody EnderecoDTO dto) {
+    public ResponseEntity<ApiResponse<EnderecoDTO>> atualizar(@PathVariable Long id, @RequestBody EnderecoDTO dto) {
         Endereco dados = new Endereco();
         BeanUtils.copyProperties(dto, dados, "idEndereco");
-        return ResponseEntity.ok(new EnderecoDTO(service.atualizar(id, dados)));
+        return ResponseEntity.ok(ApiResponse.ok(new EnderecoDTO(service.atualizar(id, dados))));
     }
 
     @Operation(summary = "Excluir endereço")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
         service.deletar(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.ok(null, "Excluído com sucesso"));
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/pessoa/EnderecoPessoaController.java
+++ b/src/main/java/com/diario/de/classe/modules/pessoa/EnderecoPessoaController.java
@@ -1,6 +1,7 @@
 package com.diario.de.classe.modules.pessoa;
 
 import com.diario.de.classe.modules.pessoa.dto.EnderecoPessoaDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
@@ -24,41 +25,41 @@ public class EnderecoPessoaController {
     @Operation(summary = "Listar todas as associações endereço-pessoa")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping
-    public ResponseEntity<List<EnderecoPessoaDTO>> listar() {
-        return ResponseEntity.ok(service.buscarTodos().stream().map(EnderecoPessoaDTO::new).toList());
+    public ResponseEntity<ApiResponse<List<EnderecoPessoaDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos().stream().map(EnderecoPessoaDTO::new).toList()));
     }
 
     @Operation(summary = "Buscar associação por ID")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping("/{id}")
-    public ResponseEntity<EnderecoPessoaDTO> buscarPorId(@PathVariable Long id) {
-        return ResponseEntity.ok(new EnderecoPessoaDTO(service.buscarPorId(id)));
+    public ResponseEntity<ApiResponse<EnderecoPessoaDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(new EnderecoPessoaDTO(service.buscarPorId(id))));
     }
 
     @Operation(summary = "Criar nova associação endereço-pessoa")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @PostMapping
-    public ResponseEntity<EnderecoPessoaDTO> criar(@RequestBody EnderecoPessoaDTO dto) {
+    public ResponseEntity<ApiResponse<EnderecoPessoaDTO>> criar(@RequestBody EnderecoPessoaDTO dto) {
         EnderecoPessoa entity = new EnderecoPessoa();
         entity.setNome(dto.getNome());
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(new EnderecoPessoaDTO(service.criar(entity, dto.getIdPessoa(), dto.getIdEndereco())));
+                .body(ApiResponse.ok(new EnderecoPessoaDTO(service.criar(entity, dto.getIdPessoa(), dto.getIdEndereco())), "Endereço da pessoa criado com sucesso"));
     }
 
     @Operation(summary = "Atualizar associação endereço-pessoa")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @PutMapping("/{id}")
-    public ResponseEntity<EnderecoPessoaDTO> atualizar(@PathVariable Long id, @RequestBody EnderecoPessoaDTO dto) {
+    public ResponseEntity<ApiResponse<EnderecoPessoaDTO>> atualizar(@PathVariable Long id, @RequestBody EnderecoPessoaDTO dto) {
         EnderecoPessoa dados = new EnderecoPessoa();
         dados.setNome(dto.getNome());
-        return ResponseEntity.ok(new EnderecoPessoaDTO(service.atualizar(id, dados)));
+        return ResponseEntity.ok(ApiResponse.ok(new EnderecoPessoaDTO(service.atualizar(id, dados))));
     }
 
     @Operation(summary = "Excluir associação endereço-pessoa")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
         service.deletar(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.ok(null, "Excluído com sucesso"));
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/pessoa/PessoaController.java
+++ b/src/main/java/com/diario/de/classe/modules/pessoa/PessoaController.java
@@ -1,6 +1,7 @@
 package com.diario.de.classe.modules.pessoa;
 
 import com.diario.de.classe.modules.pessoa.dto.PessoaDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.BeanUtils;
@@ -25,41 +26,41 @@ public class PessoaController {
     @Operation(summary = "Listar todas as pessoas")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'DIRETOR')")
     @GetMapping
-    public ResponseEntity<List<PessoaDTO>> listar() {
+    public ResponseEntity<ApiResponse<List<PessoaDTO>>> listar() {
         List<PessoaDTO> dtos = service.buscarTodos().stream().map(PessoaDTO::new).toList();
-        return ResponseEntity.ok(dtos);
+        return ResponseEntity.ok(ApiResponse.ok(dtos));
     }
 
     @Operation(summary = "Buscar pessoa por ID")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
     @GetMapping("/{id}")
-    public ResponseEntity<PessoaDTO> buscarPorId(@PathVariable Long id) {
-        return ResponseEntity.ok(new PessoaDTO(service.buscarPorId(id)));
+    public ResponseEntity<ApiResponse<PessoaDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(new PessoaDTO(service.buscarPorId(id))));
     }
 
     @Operation(summary = "Criar nova pessoa")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @PostMapping
-    public ResponseEntity<PessoaDTO> criar(@RequestBody PessoaDTO dto) {
+    public ResponseEntity<ApiResponse<PessoaDTO>> criar(@RequestBody PessoaDTO dto) {
         Pessoa entity = new Pessoa();
         BeanUtils.copyProperties(dto, entity, "idPessoa", "idTipoPessoa");
-        return ResponseEntity.status(HttpStatus.CREATED).body(new PessoaDTO(service.criar(entity, dto.getIdTipoPessoa())));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(new PessoaDTO(service.criar(entity, dto.getIdTipoPessoa())), "Pessoa criada com sucesso"));
     }
 
     @Operation(summary = "Atualizar pessoa")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @PutMapping("/{id}")
-    public ResponseEntity<PessoaDTO> atualizar(@PathVariable Long id, @RequestBody PessoaDTO dto) {
+    public ResponseEntity<ApiResponse<PessoaDTO>> atualizar(@PathVariable Long id, @RequestBody PessoaDTO dto) {
         Pessoa dados = new Pessoa();
         BeanUtils.copyProperties(dto, dados, "idPessoa", "idTipoPessoa");
-        return ResponseEntity.ok(new PessoaDTO(service.atualizar(id, dados, dto.getIdTipoPessoa())));
+        return ResponseEntity.ok(ApiResponse.ok(new PessoaDTO(service.atualizar(id, dados, dto.getIdTipoPessoa()))));
     }
 
     @Operation(summary = "Excluir pessoa")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
         service.deletar(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.ok(null, "Excluído com sucesso"));
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/pessoa/PessoaResponsavelController.java
+++ b/src/main/java/com/diario/de/classe/modules/pessoa/PessoaResponsavelController.java
@@ -1,6 +1,7 @@
 package com.diario.de.classe.modules.pessoa;
 
 import com.diario.de.classe.modules.pessoa.dto.PessoaResponsavelDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
@@ -24,41 +25,41 @@ public class PessoaResponsavelController {
     @Operation(summary = "Listar todos os vínculos aluno-responsável")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping
-    public ResponseEntity<List<PessoaResponsavelDTO>> listar() {
-        return ResponseEntity.ok(service.buscarTodos().stream().map(PessoaResponsavelDTO::new).toList());
+    public ResponseEntity<ApiResponse<List<PessoaResponsavelDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos().stream().map(PessoaResponsavelDTO::new).toList()));
     }
 
     @Operation(summary = "Buscar vínculo por ID")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping("/{id}")
-    public ResponseEntity<PessoaResponsavelDTO> buscarPorId(@PathVariable Long id) {
-        return ResponseEntity.ok(new PessoaResponsavelDTO(service.buscarPorId(id)));
+    public ResponseEntity<ApiResponse<PessoaResponsavelDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(new PessoaResponsavelDTO(service.buscarPorId(id))));
     }
 
     @Operation(summary = "Criar vínculo aluno-responsável")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @PostMapping
-    public ResponseEntity<PessoaResponsavelDTO> criar(@RequestBody PessoaResponsavelDTO dto) {
+    public ResponseEntity<ApiResponse<PessoaResponsavelDTO>> criar(@RequestBody PessoaResponsavelDTO dto) {
         PessoaResponsavel entity = new PessoaResponsavel();
         entity.setParentesco(dto.getParentesco());
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(new PessoaResponsavelDTO(service.criar(entity, dto.getIdAluno(), dto.getIdResponsavel())));
+                .body(ApiResponse.ok(new PessoaResponsavelDTO(service.criar(entity, dto.getIdAluno(), dto.getIdResponsavel())), "Vínculo com responsável criado com sucesso"));
     }
 
     @Operation(summary = "Atualizar vínculo aluno-responsável")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @PutMapping("/{id}")
-    public ResponseEntity<PessoaResponsavelDTO> atualizar(@PathVariable Long id, @RequestBody PessoaResponsavelDTO dto) {
+    public ResponseEntity<ApiResponse<PessoaResponsavelDTO>> atualizar(@PathVariable Long id, @RequestBody PessoaResponsavelDTO dto) {
         PessoaResponsavel dados = new PessoaResponsavel();
         dados.setParentesco(dto.getParentesco());
-        return ResponseEntity.ok(new PessoaResponsavelDTO(service.atualizar(id, dados)));
+        return ResponseEntity.ok(ApiResponse.ok(new PessoaResponsavelDTO(service.atualizar(id, dados))));
     }
 
     @Operation(summary = "Excluir vínculo aluno-responsável")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
         service.deletar(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.ok(null, "Excluído com sucesso"));
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/pessoa/TipoPessoaController.java
+++ b/src/main/java/com/diario/de/classe/modules/pessoa/TipoPessoaController.java
@@ -1,6 +1,7 @@
 package com.diario.de.classe.modules.pessoa;
 
 import com.diario.de.classe.modules.pessoa.dto.TipoPessoaDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.BeanUtils;
@@ -25,41 +26,41 @@ public class TipoPessoaController {
     @Operation(summary = "Listar todos os tipos de pessoa")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @GetMapping
-    public ResponseEntity<List<TipoPessoaDTO>> listar() {
+    public ResponseEntity<ApiResponse<List<TipoPessoaDTO>>> listar() {
         List<TipoPessoaDTO> dtos = service.buscarTodos().stream().map(TipoPessoaDTO::new).toList();
-        return ResponseEntity.ok(dtos);
+        return ResponseEntity.ok(ApiResponse.ok(dtos));
     }
 
     @Operation(summary = "Buscar tipo de pessoa por ID")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @GetMapping("/{id}")
-    public ResponseEntity<TipoPessoaDTO> buscarPorId(@PathVariable Long id) {
-        return ResponseEntity.ok(new TipoPessoaDTO(service.buscarPorId(id)));
+    public ResponseEntity<ApiResponse<TipoPessoaDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(new TipoPessoaDTO(service.buscarPorId(id))));
     }
 
     @Operation(summary = "Criar novo tipo de pessoa")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @PostMapping
-    public ResponseEntity<TipoPessoaDTO> criar(@RequestBody TipoPessoaDTO dto) {
+    public ResponseEntity<ApiResponse<TipoPessoaDTO>> criar(@RequestBody TipoPessoaDTO dto) {
         TipoPessoa entity = new TipoPessoa();
         BeanUtils.copyProperties(dto, entity);
-        return ResponseEntity.status(HttpStatus.CREATED).body(new TipoPessoaDTO(service.criar(entity)));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(new TipoPessoaDTO(service.criar(entity)), "Tipo de pessoa criado com sucesso"));
     }
 
     @Operation(summary = "Atualizar tipo de pessoa")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @PutMapping("/{id}")
-    public ResponseEntity<TipoPessoaDTO> atualizar(@PathVariable Long id, @RequestBody TipoPessoaDTO dto) {
+    public ResponseEntity<ApiResponse<TipoPessoaDTO>> atualizar(@PathVariable Long id, @RequestBody TipoPessoaDTO dto) {
         TipoPessoa dados = new TipoPessoa();
         BeanUtils.copyProperties(dto, dados);
-        return ResponseEntity.ok(new TipoPessoaDTO(service.atualizar(id, dados)));
+        return ResponseEntity.ok(ApiResponse.ok(new TipoPessoaDTO(service.atualizar(id, dados))));
     }
 
     @Operation(summary = "Excluir tipo de pessoa")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
         service.deletar(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.ok(null, "Excluído com sucesso"));
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/turma/AlunoTurmaController.java
+++ b/src/main/java/com/diario/de/classe/modules/turma/AlunoTurmaController.java
@@ -1,6 +1,7 @@
 package com.diario.de.classe.modules.turma;
 
 import com.diario.de.classe.modules.turma.dto.AlunoTurmaDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.BeanUtils;
@@ -23,41 +24,41 @@ public class AlunoTurmaController {
     @Operation(summary = "Listar todos os alunos por turma")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
     @GetMapping
-    public ResponseEntity<List<AlunoTurmaDTO>> listar() {
-        return ResponseEntity.ok(service.buscarTodos().stream().map(AlunoTurmaDTO::new).toList());
+    public ResponseEntity<ApiResponse<List<AlunoTurmaDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos().stream().map(AlunoTurmaDTO::new).toList()));
     }
 
     @Operation(summary = "Buscar aluno-turma por ID")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
     @GetMapping("/{id}")
-    public ResponseEntity<AlunoTurmaDTO> buscarPorId(@PathVariable Long id) {
-        return ResponseEntity.ok(new AlunoTurmaDTO(service.buscarPorId(id)));
+    public ResponseEntity<ApiResponse<AlunoTurmaDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(new AlunoTurmaDTO(service.buscarPorId(id))));
     }
 
     @Operation(summary = "Adicionar aluno à turma")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @PostMapping
-    public ResponseEntity<AlunoTurmaDTO> criar(@RequestBody AlunoTurmaDTO dto) {
+    public ResponseEntity<ApiResponse<AlunoTurmaDTO>> criar(@RequestBody AlunoTurmaDTO dto) {
         AlunoTurma entity = new AlunoTurma();
         entity.setObs(dto.getObs());
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(new AlunoTurmaDTO(service.criar(entity, dto.getIdAluno(), dto.getIdTurma())));
+                .body(ApiResponse.ok(new AlunoTurmaDTO(service.criar(entity, dto.getIdAluno(), dto.getIdTurma())), "Aluno adicionado à turma com sucesso"));
     }
 
     @Operation(summary = "Atualizar aluno-turma")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @PutMapping("/{id}")
-    public ResponseEntity<AlunoTurmaDTO> atualizar(@PathVariable Long id, @RequestBody AlunoTurmaDTO dto) {
+    public ResponseEntity<ApiResponse<AlunoTurmaDTO>> atualizar(@PathVariable Long id, @RequestBody AlunoTurmaDTO dto) {
         AlunoTurma dados = new AlunoTurma();
         BeanUtils.copyProperties(dto, dados, "idAlunoTurma");
-        return ResponseEntity.ok(new AlunoTurmaDTO(service.atualizar(id, dados, dto.getIdAluno(), dto.getIdTurma())));
+        return ResponseEntity.ok(ApiResponse.ok(new AlunoTurmaDTO(service.atualizar(id, dados, dto.getIdAluno(), dto.getIdTurma()))));
     }
 
     @Operation(summary = "Remover aluno da turma")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
         service.deletar(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.ok(null, "Excluído com sucesso"));
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/turma/ClasseController.java
+++ b/src/main/java/com/diario/de/classe/modules/turma/ClasseController.java
@@ -1,6 +1,7 @@
 package com.diario.de.classe.modules.turma;
 
 import com.diario.de.classe.modules.turma.dto.ClasseDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
@@ -22,42 +23,42 @@ public class ClasseController {
     @Operation(summary = "Listar todas as classes")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping
-    public ResponseEntity<List<ClasseDTO>> listar() {
-        return ResponseEntity.ok(service.buscarTodos().stream().map(ClasseDTO::new).toList());
+    public ResponseEntity<ApiResponse<List<ClasseDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos().stream().map(ClasseDTO::new).toList()));
     }
 
     @Operation(summary = "Buscar classe por ID")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping("/{id}")
-    public ResponseEntity<ClasseDTO> buscarPorId(@PathVariable Long id) {
-        return ResponseEntity.ok(new ClasseDTO(service.buscarPorId(id)));
+    public ResponseEntity<ApiResponse<ClasseDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(new ClasseDTO(service.buscarPorId(id))));
     }
 
     @Operation(summary = "Criar nova classe")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @PostMapping
-    public ResponseEntity<ClasseDTO> criar(@RequestBody ClasseDTO dto) {
+    public ResponseEntity<ApiResponse<ClasseDTO>> criar(@RequestBody ClasseDTO dto) {
         Classe entity = new Classe();
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(new ClasseDTO(service.criar(entity, dto.getIdInstituicaoEnsino(),
+                .body(ApiResponse.ok(new ClasseDTO(service.criar(entity, dto.getIdInstituicaoEnsino(),
                         dto.getIdComponenteCurricular(), dto.getIdCurso(), dto.getIdTurno(),
-                        dto.getIdTurma(), dto.getIdProfessor())));
+                        dto.getIdTurma(), dto.getIdProfessor())), "Classe criada com sucesso"));
     }
 
     @Operation(summary = "Atualizar classe")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @PutMapping("/{id}")
-    public ResponseEntity<ClasseDTO> atualizar(@PathVariable Long id, @RequestBody ClasseDTO dto) {
-        return ResponseEntity.ok(new ClasseDTO(service.atualizar(id, dto.getIdInstituicaoEnsino(),
+    public ResponseEntity<ApiResponse<ClasseDTO>> atualizar(@PathVariable Long id, @RequestBody ClasseDTO dto) {
+        return ResponseEntity.ok(ApiResponse.ok(new ClasseDTO(service.atualizar(id, dto.getIdInstituicaoEnsino(),
                 dto.getIdComponenteCurricular(), dto.getIdCurso(), dto.getIdTurno(),
-                dto.getIdTurma(), dto.getIdProfessor())));
+                dto.getIdTurma(), dto.getIdProfessor()))));
     }
 
     @Operation(summary = "Excluir classe")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
         service.deletar(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.ok(null, "Excluído com sucesso"));
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/turma/ComponenteCurricularController.java
+++ b/src/main/java/com/diario/de/classe/modules/turma/ComponenteCurricularController.java
@@ -1,6 +1,7 @@
 package com.diario.de.classe.modules.turma;
 
 import com.diario.de.classe.modules.turma.dto.ComponenteCurricularDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.BeanUtils;
@@ -23,40 +24,40 @@ public class ComponenteCurricularController {
     @Operation(summary = "Listar todos os componentes curriculares")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping
-    public ResponseEntity<List<ComponenteCurricularDTO>> listar() {
-        return ResponseEntity.ok(service.buscarTodos().stream().map(ComponenteCurricularDTO::new).toList());
+    public ResponseEntity<ApiResponse<List<ComponenteCurricularDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos().stream().map(ComponenteCurricularDTO::new).toList()));
     }
 
     @Operation(summary = "Buscar componente curricular por ID")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping("/{id}")
-    public ResponseEntity<ComponenteCurricularDTO> buscarPorId(@PathVariable Long id) {
-        return ResponseEntity.ok(new ComponenteCurricularDTO(service.buscarPorId(id)));
+    public ResponseEntity<ApiResponse<ComponenteCurricularDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(new ComponenteCurricularDTO(service.buscarPorId(id))));
     }
 
     @Operation(summary = "Criar novo componente curricular")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @PostMapping
-    public ResponseEntity<ComponenteCurricularDTO> criar(@RequestBody ComponenteCurricularDTO dto) {
+    public ResponseEntity<ApiResponse<ComponenteCurricularDTO>> criar(@RequestBody ComponenteCurricularDTO dto) {
         ComponenteCurricular entity = new ComponenteCurricular();
         BeanUtils.copyProperties(dto, entity, "idComponenteCurricular");
-        return ResponseEntity.status(HttpStatus.CREATED).body(new ComponenteCurricularDTO(service.criar(entity)));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(new ComponenteCurricularDTO(service.criar(entity)), "Componente curricular criado com sucesso"));
     }
 
     @Operation(summary = "Atualizar componente curricular")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @PutMapping("/{id}")
-    public ResponseEntity<ComponenteCurricularDTO> atualizar(@PathVariable Long id, @RequestBody ComponenteCurricularDTO dto) {
+    public ResponseEntity<ApiResponse<ComponenteCurricularDTO>> atualizar(@PathVariable Long id, @RequestBody ComponenteCurricularDTO dto) {
         ComponenteCurricular dados = new ComponenteCurricular();
         BeanUtils.copyProperties(dto, dados, "idComponenteCurricular");
-        return ResponseEntity.ok(new ComponenteCurricularDTO(service.atualizar(id, dados)));
+        return ResponseEntity.ok(ApiResponse.ok(new ComponenteCurricularDTO(service.atualizar(id, dados))));
     }
 
     @Operation(summary = "Excluir componente curricular")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
         service.deletar(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.ok(null, "Excluído com sucesso"));
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/turma/DisciplinaController.java
+++ b/src/main/java/com/diario/de/classe/modules/turma/DisciplinaController.java
@@ -1,6 +1,7 @@
 package com.diario.de.classe.modules.turma;
 
 import com.diario.de.classe.modules.turma.dto.DisciplinaDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.BeanUtils;
@@ -23,40 +24,40 @@ public class DisciplinaController {
     @Operation(summary = "Listar todas as disciplinas")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping
-    public ResponseEntity<List<DisciplinaDTO>> listar() {
-        return ResponseEntity.ok(service.buscarTodos().stream().map(DisciplinaDTO::new).toList());
+    public ResponseEntity<ApiResponse<List<DisciplinaDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos().stream().map(DisciplinaDTO::new).toList()));
     }
 
     @Operation(summary = "Buscar disciplina por ID")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping("/{id}")
-    public ResponseEntity<DisciplinaDTO> buscarPorId(@PathVariable Long id) {
-        return ResponseEntity.ok(new DisciplinaDTO(service.buscarPorId(id)));
+    public ResponseEntity<ApiResponse<DisciplinaDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(new DisciplinaDTO(service.buscarPorId(id))));
     }
 
     @Operation(summary = "Criar nova disciplina")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @PostMapping
-    public ResponseEntity<DisciplinaDTO> criar(@RequestBody DisciplinaDTO dto) {
+    public ResponseEntity<ApiResponse<DisciplinaDTO>> criar(@RequestBody DisciplinaDTO dto) {
         Disciplina entity = new Disciplina();
         BeanUtils.copyProperties(dto, entity, "idDisciplina");
-        return ResponseEntity.status(HttpStatus.CREATED).body(new DisciplinaDTO(service.criar(entity)));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(new DisciplinaDTO(service.criar(entity)), "Disciplina criada com sucesso"));
     }
 
     @Operation(summary = "Atualizar disciplina")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @PutMapping("/{id}")
-    public ResponseEntity<DisciplinaDTO> atualizar(@PathVariable Long id, @RequestBody DisciplinaDTO dto) {
+    public ResponseEntity<ApiResponse<DisciplinaDTO>> atualizar(@PathVariable Long id, @RequestBody DisciplinaDTO dto) {
         Disciplina dados = new Disciplina();
         BeanUtils.copyProperties(dto, dados, "idDisciplina");
-        return ResponseEntity.ok(new DisciplinaDTO(service.atualizar(id, dados)));
+        return ResponseEntity.ok(ApiResponse.ok(new DisciplinaDTO(service.atualizar(id, dados))));
     }
 
     @Operation(summary = "Excluir disciplina")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
         service.deletar(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.ok(null, "Excluído com sucesso"));
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/turma/TurmaController.java
+++ b/src/main/java/com/diario/de/classe/modules/turma/TurmaController.java
@@ -1,6 +1,7 @@
 package com.diario.de.classe.modules.turma;
 
 import com.diario.de.classe.modules.turma.dto.TurmaDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.BeanUtils;
@@ -23,40 +24,40 @@ public class TurmaController {
     @Operation(summary = "Listar todas as turmas")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping
-    public ResponseEntity<List<TurmaDTO>> listar() {
-        return ResponseEntity.ok(service.buscarTodos().stream().map(TurmaDTO::new).toList());
+    public ResponseEntity<ApiResponse<List<TurmaDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos().stream().map(TurmaDTO::new).toList()));
     }
 
     @Operation(summary = "Buscar turma por ID")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @GetMapping("/{id}")
-    public ResponseEntity<TurmaDTO> buscarPorId(@PathVariable Long id) {
-        return ResponseEntity.ok(new TurmaDTO(service.buscarPorId(id)));
+    public ResponseEntity<ApiResponse<TurmaDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(new TurmaDTO(service.buscarPorId(id))));
     }
 
     @Operation(summary = "Criar nova turma")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @PostMapping
-    public ResponseEntity<TurmaDTO> criar(@RequestBody TurmaDTO dto) {
+    public ResponseEntity<ApiResponse<TurmaDTO>> criar(@RequestBody TurmaDTO dto) {
         Turma entity = new Turma();
         BeanUtils.copyProperties(dto, entity, "idTurma");
-        return ResponseEntity.status(HttpStatus.CREATED).body(new TurmaDTO(service.criar(entity)));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(new TurmaDTO(service.criar(entity)), "Turma criada com sucesso"));
     }
 
     @Operation(summary = "Atualizar turma")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @PutMapping("/{id}")
-    public ResponseEntity<TurmaDTO> atualizar(@PathVariable Long id, @RequestBody TurmaDTO dto) {
+    public ResponseEntity<ApiResponse<TurmaDTO>> atualizar(@PathVariable Long id, @RequestBody TurmaDTO dto) {
         Turma dados = new Turma();
         BeanUtils.copyProperties(dto, dados, "idTurma");
-        return ResponseEntity.ok(new TurmaDTO(service.atualizar(id, dados)));
+        return ResponseEntity.ok(ApiResponse.ok(new TurmaDTO(service.atualizar(id, dados))));
     }
 
     @Operation(summary = "Excluir turma")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
         service.deletar(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.ok(null, "Excluído com sucesso"));
     }
 }

--- a/src/main/java/com/diario/de/classe/shared/dto/ApiResponse.java
+++ b/src/main/java/com/diario/de/classe/shared/dto/ApiResponse.java
@@ -1,0 +1,50 @@
+package com.diario.de.classe.shared.dto;
+
+/**
+ * Wrapper padrão para todas as respostas da API.
+ *
+ * Garante um formato JSON consistente para o frontend, independente do endpoint:
+ *
+ * Sucesso:
+ * {
+ *   "success": true,
+ *   "data": { ... },
+ *   "message": null,
+ *   "error": null
+ * }
+ *
+ * Erro:
+ * {
+ *   "success": false,
+ *   "data": null,
+ *   "message": null,
+ *   "error": "Mensagem de erro"
+ * }
+ *
+ * Uso no Controller:
+ *   return ResponseEntity.ok(ApiResponse.ok(service.listar()));
+ *   return ResponseEntity.status(CREATED).body(ApiResponse.ok(dto, "Criado com sucesso"));
+ *   return ResponseEntity.ok(ApiResponse.error("Recurso não encontrado"));
+ */
+public record ApiResponse<T>(
+        boolean success,
+        T data,
+        String message,
+        Object error
+) {
+
+    /** Resposta de sucesso com dados, sem mensagem. */
+    public static <T> ApiResponse<T> ok(T data) {
+        return new ApiResponse<>(true, data, null, null);
+    }
+
+    /** Resposta de sucesso com dados e mensagem descritiva (ex: "Cadastrado com sucesso"). */
+    public static <T> ApiResponse<T> ok(T data, String message) {
+        return new ApiResponse<>(true, data, message, null);
+    }
+
+    /** Resposta de erro com mensagem (data fica null). */
+    public static ApiResponse<?> error(String errorMessage) {
+        return new ApiResponse<>(false, null, null, errorMessage);
+    }
+}

--- a/src/main/java/com/diario/de/classe/shared/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/diario/de/classe/shared/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.diario.de.classe.shared.exception;
 
+import com.diario.de.classe.shared.dto.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -12,7 +13,7 @@ import java.util.stream.Collectors;
  * Centralizador de tratamento de exceções da API.
  *
  * Intercepta exceções lançadas em qualquer Controller e retorna respostas
- * padronizadas, evitando que stacktraces vazem para o cliente.
+ * padronizadas com ApiResponse, evitando que stacktraces vazem para o cliente.
  */
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -22,8 +23,9 @@ public class GlobalExceptionHandler {
      * Lançada quando um ID não existe no banco.
      */
     @ExceptionHandler(ResourceNotFoundException.class)
-    public ResponseEntity<String> handleNotFound(ResourceNotFoundException ex) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    public ResponseEntity<ApiResponse<?>> handleNotFound(ResourceNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.error(ex.getMessage()));
     }
 
     /**
@@ -31,8 +33,9 @@ public class GlobalExceptionHandler {
      * Exemplos: aluno já matriculado, frequência duplicada.
      */
     @ExceptionHandler(BusinessException.class)
-    public ResponseEntity<String> handleBusiness(BusinessException ex) {
-        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(ex.getMessage());
+    public ResponseEntity<ApiResponse<?>> handleBusiness(BusinessException ex) {
+        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(ApiResponse.error(ex.getMessage()));
     }
 
     /**
@@ -40,19 +43,22 @@ public class GlobalExceptionHandler {
      * Concatena todas as mensagens de validação em uma única string.
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<String> handleValidation(MethodArgumentNotValidException ex) {
+    public ResponseEntity<ApiResponse<?>> handleValidation(MethodArgumentNotValidException ex) {
         String message = ex.getBindingResult().getFieldErrors().stream()
                 .map(e -> e.getField() + ": " + e.getDefaultMessage())
                 .collect(Collectors.joining(", "));
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(message);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error(message));
     }
 
     /**
      * Fallback para exceções não tratadas — HTTP 500.
+     * Não expõe detalhes técnicos ao cliente; registrar o erro no log é responsabilidade
+     * do RequestLoggingInterceptor ou de um sistema de observabilidade.
      */
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<String> handleGeneral(Exception ex) {
+    public ResponseEntity<ApiResponse<?>> handleGeneral(Exception ex) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body("Erro interno: " + ex.getMessage());
+                .body(ApiResponse.error("Erro interno do servidor. Tente novamente mais tarde."));
     }
 }


### PR DESCRIPTION
ETAPA 4 concluída. Resumo:

Criado:

shared/dto/ApiResponse.java — record com ok(data), ok(data, message) e error(message)
Atualizado — GlobalExceptionHandler:

Todos os handlers agora retornam ResponseEntity<ApiResponse<?>> em vez de String
Handler genérico (500) não expõe mais detalhes técnicos ao cliente
Atualizados — 26 controllers (25 módulos + AuthController):

Mudança	Antes	Depois
Retorno de listagem	ResponseEntity<List<XxxDTO>>	ResponseEntity<ApiResponse<List<XxxDTO>>>
Retorno de busca	ResponseEntity<XxxDTO>	ResponseEntity<ApiResponse<XxxDTO>>
Retorno de criação	ResponseEntity.status(CREATED).body(dto)	ApiResponse.ok(dto, "Xxx criado com sucesso")
Retorno de delete	ResponseEntity.noContent().build()	ApiResponse.ok(null, "Excluído com sucesso")
AuthController	Expunha entidade User diretamente	Retorna ApiResponse<Void> no register/login
AuthController	@RequestMapping("/auth")	@RequestMapping("/v1/auth") ✅