### PR TITLE
fluxode matrículas de aluno e fluxo de lançamento de frequencia

### DIFF
--- a/src/main/java/com/diario/de/classe/modules/frequencia/AlunoFrequencia.java
+++ b/src/main/java/com/diario/de/classe/modules/frequencia/AlunoFrequencia.java
@@ -7,6 +7,15 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+/**
+ * Registro de frequência de um aluno em uma aula específica.
+ *
+ * <p>Cada instância representa a ocorrência de <strong>um aluno</strong>
+ * em <strong>uma entrada de calendário escolar</strong> (aula/dia letivo).
+ * O tipo determina se o aluno estava presente, faltou ou tem justificativa.
+ *
+ * @see TipoFrequencia
+ */
 @Entity
 @Table(name = "aluno_frequencia")
 @Data
@@ -18,16 +27,23 @@ public class AlunoFrequencia extends BaseEntity {
     @Column(name = "id_aluno_frequencia")
     private Long idAlunoFrequencia;
 
+    /** Aluno (Pessoa com tipo ALUNO) ao qual a frequência pertence. */
     @ManyToOne
     @JoinColumn(name = "id_aluno", nullable = false, referencedColumnName = "id_pessoa",
             foreignKey = @ForeignKey(name = "fk_id_aluno"))
     private Pessoa pessoaAluno;
 
+    /** Calendário escolar (aula/dia) ao qual esta frequência se refere. */
     @ManyToOne
     @JoinColumn(name = "id_calendario_escolar", nullable = false, referencedColumnName = "id_calendario_escolar",
             foreignKey = @ForeignKey(name = "fk_id_calendario_escolar"))
     private CalendarioEscolar calendarioEscolar;
 
-    @Column(name = "faltas")
-    private String faltas;
+    /**
+     * Tipo da frequência: PRESENTE, FALTA ou FALTA_JUSTIFICADA.
+     * Armazenado como String (EnumType.STRING) para legibilidade no banco.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tipo_frequencia", nullable = false, length = 30)
+    private TipoFrequencia tipoFrequencia = TipoFrequencia.PRESENTE;
 }

--- a/src/main/java/com/diario/de/classe/modules/frequencia/AlunoFrequenciaController.java
+++ b/src/main/java/com/diario/de/classe/modules/frequencia/AlunoFrequenciaController.java
@@ -1,6 +1,7 @@
 package com.diario.de.classe.modules.frequencia;
 
 import com.diario.de.classe.modules.frequencia.dto.AlunoFrequenciaDTO;
+import com.diario.de.classe.modules.frequencia.dto.FrequenciaResumoDTO;
 import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -10,23 +11,57 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
+/**
+ * Controller de frequência de alunos.
+ *
+ * <p>Rotas disponíveis:
+ * <ul>
+ *   <li>{@code GET /v1/frequencias} — lista todos os registros ativos.</li>
+ *   <li>{@code GET /v1/frequencias/{id}} — busca por ID.</li>
+ *   <li>{@code GET /v1/frequencias/aluno/{idAluno}} — histórico de frequência do aluno.</li>
+ *   <li>{@code GET /v1/frequencias/aluno/{idAluno}/resumo} — percentual LDB e risco de reprovação.</li>
+ *   <li>{@code POST /v1/frequencias} — lança frequência de um aluno em uma aula.</li>
+ *   <li>{@code POST /v1/frequencias/turma/{idTurma}/calendario/{idCalendario}} — lança em lote para toda a turma.</li>
+ *   <li>{@code PUT /v1/frequencias/{id}} — corrige o tipo de frequência.</li>
+ *   <li>{@code DELETE /v1/frequencias/{id}} — desativa (soft delete).</li>
+ * </ul>
+ */
 @RestController
 @RequestMapping("/v1/frequencias")
-@Tag(name = "AlunoFrequencia", description = "Gerenciamento de frequência de alunos")
+@Tag(name = "Frequência", description = "Lançamento e consulta de frequência de alunos (LDB Art. 24 — mínimo 75%)")
 public class AlunoFrequenciaController {
 
     private final AlunoFrequenciaService service;
 
-    public AlunoFrequenciaController(AlunoFrequenciaService service) { this.service = service; }
+    public AlunoFrequenciaController(AlunoFrequenciaService service) {
+        this.service = service;
+    }
 
-    @Operation(summary = "Listar todas as frequências")
+    // -------------------------------------------------------------------------
+    // Consultas
+    // -------------------------------------------------------------------------
+
+    /**
+     * Lista todos os registros de frequência ativos no sistema.
+     * Registros desativados via soft delete não aparecem.
+     */
+    @Operation(summary = "Listar todas as frequências ativas")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
     @GetMapping
     public ResponseEntity<ApiResponse<List<AlunoFrequenciaDTO>>> listar() {
-        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos().stream().map(AlunoFrequenciaDTO::new).toList()));
+        return ResponseEntity.ok(ApiResponse.ok(
+                service.buscarTodos().stream().map(AlunoFrequenciaDTO::new).toList()
+        ));
     }
 
+    /**
+     * Busca um registro de frequência pelo ID.
+     *
+     * @param id ID do registro
+     * @return frequência encontrada ou 404
+     */
     @Operation(summary = "Buscar frequência por ID")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
     @GetMapping("/{id}")
@@ -34,30 +69,143 @@ public class AlunoFrequenciaController {
         return ResponseEntity.ok(ApiResponse.ok(new AlunoFrequenciaDTO(service.buscarPorId(id))));
     }
 
-    @Operation(summary = "Registrar frequência de aluno")
+    /**
+     * Lista o histórico de frequência de um aluno específico.
+     *
+     * @param idAluno ID da Pessoa com tipo ALUNO
+     * @return lista de registros ativos do aluno
+     */
+    @Operation(summary = "Listar frequências de um aluno")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
+    @GetMapping("/aluno/{idAluno}")
+    public ResponseEntity<ApiResponse<List<AlunoFrequenciaDTO>>> listarPorAluno(@PathVariable Long idAluno) {
+        return ResponseEntity.ok(ApiResponse.ok(
+                service.buscarPorAluno(idAluno).stream().map(AlunoFrequenciaDTO::new).toList()
+        ));
+    }
+
+    /**
+     * Calcula e retorna o resumo de frequência de um aluno.
+     *
+     * <p>Inclui: total de aulas, total de presenças/faltas/justificadas,
+     * percentual de presença e indicador de risco de reprovação (< 75% LDB).
+     *
+     * @param idAluno ID do aluno
+     * @return resumo com percentual calculado
+     */
+    @Operation(summary = "Calcular resumo de frequência do aluno (percentual LDB)")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
+    @GetMapping("/aluno/{idAluno}/resumo")
+    public ResponseEntity<ApiResponse<FrequenciaResumoDTO>> calcularResumo(@PathVariable Long idAluno) {
+        return ResponseEntity.ok(ApiResponse.ok(service.calcularFrequencia(idAluno)));
+    }
+
+    // -------------------------------------------------------------------------
+    // Lançamento de frequência
+    // -------------------------------------------------------------------------
+
+    /**
+     * Registra a frequência de um único aluno em uma aula.
+     *
+     * <p>Aplica regra de duplicidade: um aluno não pode ter dois registros ativos
+     * para a mesma aula. Retorna HTTP 422 se isso ocorrer.
+     *
+     * <p>Exemplo de corpo:
+     * <pre>{@code
+     * { "idAluno": 1, "idCalendarioEscolar": 5, "tipoFrequencia": "FALTA" }
+     * }</pre>
+     *
+     * @param dto DTO com idAluno, idCalendarioEscolar e tipoFrequencia (opcional, padrão PRESENTE)
+     * @return registro criado
+     */
+    @Operation(summary = "Registrar frequência de um aluno em uma aula")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'PROFESSOR')")
     @PostMapping
-    public ResponseEntity<ApiResponse<AlunoFrequenciaDTO>> criar(@RequestBody AlunoFrequenciaDTO dto) {
-        AlunoFrequencia entity = new AlunoFrequencia();
-        entity.setFaltas(dto.getFaltas());
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.ok(new AlunoFrequenciaDTO(service.criar(entity, dto.getIdAluno(), dto.getIdCalendarioEscolar())), "Frequência criada com sucesso"));
+    public ResponseEntity<ApiResponse<AlunoFrequenciaDTO>> registrar(@RequestBody AlunoFrequenciaDTO dto) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(
+                new AlunoFrequenciaDTO(service.registrar(dto.getIdAluno(), dto.getIdCalendarioEscolar(), dto.getTipoFrequencia())),
+                "Frequência registrada com sucesso"
+        ));
     }
 
-    @Operation(summary = "Atualizar frequência de aluno")
+    /**
+     * Lança frequência em lote para todos os alunos matriculados em uma turma.
+     *
+     * <p>Útil para o professor registrar a chamada de uma aula inteira. Alunos já com
+     * frequência registrada para esta aula são ignorados (sem erro).
+     *
+     * <p>O corpo é um mapa opcional de {@code idAluno → TipoFrequencia}.
+     * Alunos não incluídos no mapa recebem o {@code tipoPadrao} (query param, padrão: PRESENTE).
+     *
+     * <p>Exemplo:
+     * <pre>{@code
+     * POST /v1/frequencias/turma/3/calendario/10?tipoPadrao=PRESENTE
+     * Body: { "2": "FALTA", "5": "FALTA_JUSTIFICADA" }
+     * }</pre>
+     *
+     * @param idTurma      ID da turma
+     * @param idCalendario ID do calendário escolar (aula)
+     * @param tipoPadrao   tipo para alunos não mapeados (padrão: PRESENTE)
+     * @param tiposPorAluno mapa de idAluno → TipoFrequencia (pode ser vazio)
+     * @return lista de registros criados neste lançamento
+     */
+    @Operation(summary = "Lançar frequência em lote para toda a turma")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'PROFESSOR')")
+    @PostMapping("/turma/{idTurma}/calendario/{idCalendario}")
+    public ResponseEntity<ApiResponse<List<AlunoFrequenciaDTO>>> registrarTurma(
+            @PathVariable Long idTurma,
+            @PathVariable Long idCalendario,
+            @RequestParam(defaultValue = "PRESENTE") TipoFrequencia tipoPadrao,
+            @RequestBody(required = false) Map<Long, TipoFrequencia> tiposPorAluno) {
+
+        List<AlunoFrequenciaDTO> resultado = service
+                .registrarTurma(idTurma, idCalendario, tiposPorAluno, tipoPadrao)
+                .stream()
+                .map(AlunoFrequenciaDTO::new)
+                .toList();
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(
+                resultado,
+                "Frequência lançada para " + resultado.size() + " aluno(s)"
+        ));
+    }
+
+    /**
+     * Corrige o tipo de frequência de um registro existente.
+     *
+     * <p>Permite ao professor corrigir um lançamento errado
+     * (ex: marcou FALTA mas o aluno estava PRESENTE).
+     *
+     * <p>Corpo: {@code { "tipoFrequencia": "PRESENTE" }}
+     *
+     * @param id  ID do registro a corrigir
+     * @param dto DTO com o novo tipoFrequencia
+     * @return registro atualizado
+     */
+    @Operation(summary = "Corrigir tipo de frequência de um registro")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'PROFESSOR')")
     @PutMapping("/{id}")
-    public ResponseEntity<ApiResponse<AlunoFrequenciaDTO>> atualizar(@PathVariable Long id, @RequestBody AlunoFrequenciaDTO dto) {
-        AlunoFrequencia dados = new AlunoFrequencia();
-        dados.setFaltas(dto.getFaltas());
-        return ResponseEntity.ok(ApiResponse.ok(new AlunoFrequenciaDTO(service.atualizar(id, dados, dto.getIdAluno(), dto.getIdCalendarioEscolar()))));
+    public ResponseEntity<ApiResponse<AlunoFrequenciaDTO>> atualizar(
+            @PathVariable Long id,
+            @RequestBody AlunoFrequenciaDTO dto) {
+        return ResponseEntity.ok(ApiResponse.ok(
+                new AlunoFrequenciaDTO(service.atualizar(id, dto.getTipoFrequencia()))
+        ));
     }
 
-    @Operation(summary = "Excluir frequência")
+    /**
+     * Desativa um registro de frequência (soft delete).
+     *
+     * <p>O registro permanece no banco com {@code ativo = false} para preservar
+     * o histórico. Após desativar, o lançamento pode ser refeito via POST.
+     *
+     * @param id ID do registro a desativar
+     */
+    @Operation(summary = "Desativar registro de frequência (soft delete)")
     @PreAuthorize("hasRole('ADMINISTRADOR')")
     @DeleteMapping("/{id}")
-    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
-        service.deletar(id);
-        return ResponseEntity.ok(ApiResponse.ok(null, "Excluído com sucesso"));
+    public ResponseEntity<ApiResponse<Void>> desativar(@PathVariable Long id) {
+        service.desativar(id);
+        return ResponseEntity.ok(ApiResponse.ok(null, "Frequência desativada com sucesso"));
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/frequencia/AlunoFrequenciaRepository.java
+++ b/src/main/java/com/diario/de/classe/modules/frequencia/AlunoFrequenciaRepository.java
@@ -1,8 +1,82 @@
 package com.diario.de.classe.modules.frequencia;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
+/**
+ * Repositório de frequência de alunos.
+ *
+ * <p>Todas as queries filtram por {@code ativo = true} para ignorar
+ * registros desativados via soft delete.
+ */
 @Repository
 public interface AlunoFrequenciaRepository extends JpaRepository<AlunoFrequencia, Long> {
+
+    /**
+     * Lista todos os registros de frequência ativos (não deletados).
+     */
+    @Query("SELECT f FROM AlunoFrequencia f WHERE f.ativo = true")
+    List<AlunoFrequencia> findAllAtivos();
+
+    /**
+     * Lista todas as frequências ativas de um aluno específico.
+     *
+     * @param idAluno ID da Pessoa com tipo ALUNO
+     */
+    @Query("SELECT f FROM AlunoFrequencia f WHERE f.pessoaAluno.idPessoa = :idAluno AND f.ativo = true")
+    List<AlunoFrequencia> findAtivosByAluno(@Param("idAluno") Long idAluno);
+
+    /**
+     * Lista frequências ativas de um aluno em um calendário escolar específico.
+     *
+     * @param idAluno             ID do aluno
+     * @param idCalendarioEscolar ID do calendário (aula/período)
+     */
+    @Query("""
+            SELECT f FROM AlunoFrequencia f
+            WHERE f.pessoaAluno.idPessoa = :idAluno
+              AND f.calendarioEscolar.idCalendarioEscolar = :idCalendario
+              AND f.ativo = true
+            """)
+    List<AlunoFrequencia> findAtivosByAlunoAndCalendario(
+            @Param("idAluno") Long idAluno,
+            @Param("idCalendario") Long idCalendarioEscolar);
+
+    /**
+     * Conta o total de registros ativos de um aluno (= total de aulas registradas).
+     *
+     * <p>Usado como denominador na fórmula: {@code percentual = (presencas / totalAulas) * 100}.
+     *
+     * @param idAluno ID do aluno
+     */
+    @Query("SELECT COUNT(f) FROM AlunoFrequencia f WHERE f.pessoaAluno.idPessoa = :idAluno AND f.ativo = true")
+    long countTotalAulasByAluno(@Param("idAluno") Long idAluno);
+
+    /**
+     * Conta os registros de um tipo específico (PRESENTE, FALTA ou FALTA_JUSTIFICADA) para um aluno.
+     *
+     * @param idAluno ID do aluno
+     * @param tipo    tipo de frequência a contar
+     */
+    @Query("""
+            SELECT COUNT(f) FROM AlunoFrequencia f
+            WHERE f.pessoaAluno.idPessoa = :idAluno
+              AND f.tipoFrequencia = :tipo
+              AND f.ativo = true
+            """)
+    long countByAlunoAndTipo(@Param("idAluno") Long idAluno, @Param("tipo") TipoFrequencia tipo);
+
+    /**
+     * Verifica se já existe um registro de frequência ativo para este aluno neste calendário.
+     * Usado para evitar lançamentos duplicados.
+     *
+     * @param idAluno             ID do aluno
+     * @param idCalendarioEscolar ID do calendário escolar
+     */
+    boolean existsByPessoaAlunoIdPessoaAndCalendarioEscolarIdCalendarioEscolarAndAtivoTrue(
+            Long idAluno, Long idCalendarioEscolar);
 }

--- a/src/main/java/com/diario/de/classe/modules/frequencia/AlunoFrequenciaService.java
+++ b/src/main/java/com/diario/de/classe/modules/frequencia/AlunoFrequenciaService.java
@@ -1,50 +1,245 @@
 package com.diario.de.classe.modules.frequencia;
 
 import com.diario.de.classe.modules.calendario.CalendarioEscolarRepository;
+import com.diario.de.classe.modules.frequencia.dto.FrequenciaResumoDTO;
 import com.diario.de.classe.modules.pessoa.PessoaRepository;
+import com.diario.de.classe.modules.turma.AlunoTurma;
+import com.diario.de.classe.modules.turma.AlunoTurmaRepository;
+import com.diario.de.classe.shared.exception.BusinessException;
 import com.diario.de.classe.shared.exception.ResourceNotFoundException;
-import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
+/**
+ * Serviço responsável pelo lançamento e consulta de frequência de alunos.
+ *
+ * <p>Regras da LDB (Lei nº 9.394/96, Art. 24):
+ * <ul>
+ *   <li>Frequência mínima: 75% do total de horas/aulas.</li>
+ *   <li>FALTA_JUSTIFICADA não conta para reprovação, mas a aula ainda ocorreu.</li>
+ *   <li>Fórmula: {@code percentual = (totalPresencas / totalAulas) * 100}</li>
+ * </ul>
+ */
 @Service
 public class AlunoFrequenciaService {
+
     private final AlunoFrequenciaRepository repository;
     private final PessoaRepository pessoaRepository;
     private final CalendarioEscolarRepository calendarioEscolarRepository;
+    private final AlunoTurmaRepository alunoTurmaRepository;
 
-    public AlunoFrequenciaService(AlunoFrequenciaRepository repository, PessoaRepository pessoaRepository,
-                                  CalendarioEscolarRepository calendarioEscolarRepository) {
+    public AlunoFrequenciaService(AlunoFrequenciaRepository repository,
+                                  PessoaRepository pessoaRepository,
+                                  CalendarioEscolarRepository calendarioEscolarRepository,
+                                  AlunoTurmaRepository alunoTurmaRepository) {
         this.repository = repository;
         this.pessoaRepository = pessoaRepository;
         this.calendarioEscolarRepository = calendarioEscolarRepository;
+        this.alunoTurmaRepository = alunoTurmaRepository;
     }
 
-    public List<AlunoFrequencia> buscarTodos() { return repository.findAll(); }
+    // -------------------------------------------------------------------------
+    // Consultas básicas
+    // -------------------------------------------------------------------------
 
+    /**
+     * Lista todos os registros de frequência ativos (exclui soft-deleted).
+     *
+     * @return lista de frequências ativas
+     */
+    public List<AlunoFrequencia> buscarTodos() {
+        return repository.findAllAtivos();
+    }
+
+    /**
+     * Busca um registro de frequência pelo ID.
+     *
+     * @param id ID do registro
+     * @return entidade encontrada
+     * @throws ResourceNotFoundException se não encontrado ou inativo
+     */
     public AlunoFrequencia buscarPorId(Long id) {
         return repository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException("Frequência de aluno não encontrada com id: " + id));
+                .orElseThrow(() -> new ResourceNotFoundException("Frequência não encontrada com id: " + id));
     }
 
-    public AlunoFrequencia criar(AlunoFrequencia alunoFrequencia, Long idAluno, Long idCalendarioEscolar) {
-        alunoFrequencia.setPessoaAluno(pessoaRepository.findById(idAluno)
-                .orElseThrow(() -> new ResourceNotFoundException("Aluno não encontrado com id: " + idAluno)));
-        alunoFrequencia.setCalendarioEscolar(calendarioEscolarRepository.findById(idCalendarioEscolar)
-                .orElseThrow(() -> new ResourceNotFoundException("Calendário escolar não encontrado com id: " + idCalendarioEscolar)));
-        return repository.save(alunoFrequencia);
+    /**
+     * Lista todas as frequências ativas de um aluno.
+     *
+     * @param idAluno ID da Pessoa com tipo ALUNO
+     * @return lista de frequências do aluno
+     */
+    public List<AlunoFrequencia> buscarPorAluno(Long idAluno) {
+        return repository.findAtivosByAluno(idAluno);
     }
 
-    public AlunoFrequencia atualizar(Long id, AlunoFrequencia dados, Long idAluno, Long idCalendarioEscolar) {
+    // -------------------------------------------------------------------------
+    // Lançamento de frequência
+    // -------------------------------------------------------------------------
+
+    /**
+     * Registra a frequência de um único aluno em uma aula.
+     *
+     * <p>Valida:
+     * <ul>
+     *   <li>Existência do aluno e do calendário escolar.</li>
+     *   <li>Duplicidade: impede dois registros ativos para o mesmo aluno/aula.</li>
+     * </ul>
+     *
+     * @param idAluno             ID do aluno
+     * @param idCalendarioEscolar ID da aula (calendário escolar)
+     * @param tipo                tipo de frequência; se nulo, assume {@link TipoFrequencia#PRESENTE}
+     * @return registro de frequência criado
+     * @throws BusinessException se já existe frequência ativa para esse aluno nesta aula
+     */
+    @Transactional
+    public AlunoFrequencia registrar(Long idAluno, Long idCalendarioEscolar, TipoFrequencia tipo) {
+        // Valida aluno
+        var aluno = pessoaRepository.findById(idAluno)
+                .orElseThrow(() -> new ResourceNotFoundException("Aluno não encontrado com id: " + idAluno));
+
+        // Valida calendário
+        var calendario = calendarioEscolarRepository.findById(idCalendarioEscolar)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Calendário escolar não encontrado com id: " + idCalendarioEscolar));
+
+        // Impede lançamento duplicado para o mesmo aluno/aula
+        if (repository.existsByPessoaAlunoIdPessoaAndCalendarioEscolarIdCalendarioEscolarAndAtivoTrue(
+                idAluno, idCalendarioEscolar)) {
+            throw new BusinessException(
+                    "Frequência já registrada para este aluno nesta aula. " +
+                    "Use PUT /v1/frequencias/{id} para corrigir.");
+        }
+
+        AlunoFrequencia frequencia = new AlunoFrequencia();
+        frequencia.setPessoaAluno(aluno);
+        frequencia.setCalendarioEscolar(calendario);
+        // Assume PRESENTE quando o tipo não for informado (lançamento padrão)
+        frequencia.setTipoFrequencia(tipo != null ? tipo : TipoFrequencia.PRESENTE);
+
+        return repository.save(frequencia);
+    }
+
+    /**
+     * Lança frequência em lote para todos os alunos matriculados em uma turma.
+     *
+     * <p>Útil para o professor registrar a chamada de uma aula inteira de uma vez.
+     * Para cada aluno ativo da turma:
+     * <ul>
+     *   <li>Usa o tipo informado no mapa {@code tiposPorAluno} se existir.</li>
+     *   <li>Usa {@code tipoPadrao} para alunos não mapeados explicitamente.</li>
+     *   <li>Ignora alunos que já possuem frequência ativa para esta aula
+     *       (não lança exceção — apenas pula).</li>
+     * </ul>
+     *
+     * @param idTurma             ID da turma
+     * @param idCalendarioEscolar ID da aula (calendário escolar)
+     * @param tiposPorAluno       mapa opcional de {@code idAluno → TipoFrequencia}
+     * @param tipoPadrao          tipo usado quando o aluno não está no mapa; padrão: PRESENTE
+     * @return lista de registros criados neste lançamento
+     */
+    @Transactional
+    public List<AlunoFrequencia> registrarTurma(Long idTurma,
+                                                Long idCalendarioEscolar,
+                                                Map<Long, TipoFrequencia> tiposPorAluno,
+                                                TipoFrequencia tipoPadrao) {
+        // Valida o calendário escolar
+        var calendario = calendarioEscolarRepository.findById(idCalendarioEscolar)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Calendário escolar não encontrado com id: " + idCalendarioEscolar));
+
+        // Busca todos os alunos ativamente matriculados na turma
+        List<AlunoTurma> matriculas = alunoTurmaRepository.findAtivosByTurmaId(idTurma);
+        if (matriculas.isEmpty()) {
+            throw new BusinessException("Nenhum aluno matriculado na turma com id: " + idTurma);
+        }
+
+        TipoFrequencia padrao = tipoPadrao != null ? tipoPadrao : TipoFrequencia.PRESENTE;
+        Map<Long, TipoFrequencia> tipos = tiposPorAluno != null ? tiposPorAluno : Map.of();
+
+        return matriculas.stream()
+                .filter(m -> !repository.existsByPessoaAlunoIdPessoaAndCalendarioEscolarIdCalendarioEscolarAndAtivoTrue(
+                        m.getPessoaAluno().getIdPessoa(), idCalendarioEscolar))
+                .map(m -> {
+                    AlunoFrequencia f = new AlunoFrequencia();
+                    f.setPessoaAluno(m.getPessoaAluno());
+                    f.setCalendarioEscolar(calendario);
+                    f.setTipoFrequencia(tipos.getOrDefault(m.getPessoaAluno().getIdPessoa(), padrao));
+                    return repository.save(f);
+                })
+                .toList();
+    }
+
+    /**
+     * Atualiza o tipo de frequência de um registro existente.
+     *
+     * <p>Permite ao professor corrigir um lançamento errado (ex: marcou FALTA, era PRESENTE).
+     *
+     * @param id   ID do registro de frequência
+     * @param tipo novo tipo de frequência
+     * @return registro atualizado
+     */
+    @Transactional
+    public AlunoFrequencia atualizar(Long id, TipoFrequencia tipo) {
         AlunoFrequencia existente = buscarPorId(id);
-        BeanUtils.copyProperties(dados, existente, "idAlunoFrequencia", "createdAt", "pessoaAluno", "calendarioEscolar");
-        if (idAluno != null) existente.setPessoaAluno(pessoaRepository.findById(idAluno)
-                .orElseThrow(() -> new ResourceNotFoundException("Aluno não encontrado com id: " + idAluno)));
-        if (idCalendarioEscolar != null) existente.setCalendarioEscolar(calendarioEscolarRepository.findById(idCalendarioEscolar)
-                .orElseThrow(() -> new ResourceNotFoundException("Calendário escolar não encontrado com id: " + idCalendarioEscolar)));
+        existente.setTipoFrequencia(tipo);
         return repository.save(existente);
     }
 
-    public void deletar(Long id) { repository.delete(buscarPorId(id)); }
+    /**
+     * Desativa (soft delete) um registro de frequência.
+     *
+     * <p>O registro permanece no banco com {@code ativo = false} para preservar
+     * o histórico pedagógico. Após desativar, o lançamento pode ser refeito.
+     *
+     * @param id ID do registro a desativar
+     */
+    @Transactional
+    public void desativar(Long id) {
+        AlunoFrequencia frequencia = buscarPorId(id);
+        frequencia.setAtivo(false);
+        frequencia.setDeletedAt(LocalDateTime.now());
+        repository.save(frequencia);
+    }
+
+    // -------------------------------------------------------------------------
+    // Cálculo de frequência (regra LDB)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Calcula o resumo de frequência de um aluno com o percentual de presença.
+     *
+     * <p>Fórmula (LDB Art. 24):
+     * {@code percentual = (totalPresencas / totalAulas) * 100}
+     *
+     * <p>Considera FALTA_JUSTIFICADA no denominador (aula ocorreu), mas
+     * não computa como falta para efeito de reprovação.
+     *
+     * @param idAluno ID do aluno
+     * @return DTO com contagens, percentual e indicador de risco (< 75%)
+     */
+    public FrequenciaResumoDTO calcularFrequencia(Long idAluno) {
+        // Verifica existência do aluno
+        if (!pessoaRepository.existsById(idAluno)) {
+            throw new ResourceNotFoundException("Aluno não encontrado com id: " + idAluno);
+        }
+
+        long totalAulas     = repository.countTotalAulasByAluno(idAluno);
+        long presencas      = repository.countByAlunoAndTipo(idAluno, TipoFrequencia.PRESENTE);
+        long faltas         = repository.countByAlunoAndTipo(idAluno, TipoFrequencia.FALTA);
+        long faltasJust     = repository.countByAlunoAndTipo(idAluno, TipoFrequencia.FALTA_JUSTIFICADA);
+
+        // Evita divisão por zero quando nenhuma aula foi registrada
+        double percentual = totalAulas > 0
+                ? ((double) presencas / totalAulas) * 100.0
+                : 0.0;
+
+        boolean emRisco = percentual < FrequenciaResumoDTO.FREQUENCIA_MINIMA_LDB;
+
+        return new FrequenciaResumoDTO(idAluno, totalAulas, presencas, faltas, faltasJust, percentual, emRisco);
+    }
 }

--- a/src/main/java/com/diario/de/classe/modules/frequencia/TipoFrequencia.java
+++ b/src/main/java/com/diario/de/classe/modules/frequencia/TipoFrequencia.java
@@ -1,0 +1,41 @@
+package com.diario.de.classe.modules.frequencia;
+
+/**
+ * Tipos de frequência de um aluno em uma aula, conforme a LDB (Lei de Diretrizes e Bases).
+ *
+ * <p>Regras de negócio:
+ * <ul>
+ *   <li>{@link #PRESENTE} — aluno compareceu. Conta como presença no cálculo do percentual.</li>
+ *   <li>{@link #FALTA} — ausência sem justificativa. Conta como falta para efeito de reprovação.</li>
+ *   <li>{@link #FALTA_JUSTIFICADA} — ausência com justificativa aceita pela instituição.
+ *       Não conta para reprovação, mas o total de aulas permanece o mesmo
+ *       (ou seja, reduz o denominador do cálculo). Veja {@link #contaParaReprovacao()}.</li>
+ * </ul>
+ *
+ * <p>Fórmula de frequência (LDB Art. 24):
+ * {@code percentual = (totalPresencas / totalAulas) * 100}
+ * Frequência mínima obrigatória: 75%.
+ */
+public enum TipoFrequencia {
+
+    /** Aluno presente na aula. */
+    PRESENTE,
+
+    /** Falta sem justificativa — conta para reprovação por frequência. */
+    FALTA,
+
+    /**
+     * Falta com justificativa aceita — não causa reprovação por frequência,
+     * mas ainda diminui o denominador do cálculo (a aula ocorreu para todos).
+     */
+    FALTA_JUSTIFICADA;
+
+    /**
+     * Indica se este tipo de ocorrência conta para reprovação por frequência.
+     *
+     * @return {@code true} somente para {@link #FALTA}
+     */
+    public boolean contaParaReprovacao() {
+        return this == FALTA;
+    }
+}

--- a/src/main/java/com/diario/de/classe/modules/frequencia/dto/AlunoFrequenciaDTO.java
+++ b/src/main/java/com/diario/de/classe/modules/frequencia/dto/AlunoFrequenciaDTO.java
@@ -1,35 +1,51 @@
 package com.diario.de.classe.modules.frequencia.dto;
 
 import com.diario.de.classe.modules.frequencia.AlunoFrequencia;
+import com.diario.de.classe.modules.frequencia.TipoFrequencia;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import lombok.Data;
-import org.springframework.beans.BeanUtils;
 
-import java.io.Serializable;
-
+/**
+ * DTO de entrada e saída para o recurso {@code AlunoFrequencia}.
+ *
+ * <p>Utilizado tanto no corpo das requisições (POST/PUT) quanto
+ * nas respostas da API, evitando expor a entidade JPA diretamente.
+ */
 @Data
-public class AlunoFrequenciaDTO implements Serializable {
-    private static final long serialVersionUID = 1L;
+public class AlunoFrequenciaDTO {
 
+    /** ID do registro de frequência (nulo na criação, preenchido nas respostas). */
     private Long idAlunoFrequencia;
 
-    @NotNull
+    /** ID da Pessoa com tipo ALUNO. Obrigatório na criação. */
+    @NotNull(message = "idAluno é obrigatório")
     private Long idAluno;
 
-    @NotNull
+    /** ID do CalendarioEscolar (aula/dia letivo). Obrigatório na criação. */
+    @NotNull(message = "idCalendarioEscolar é obrigatório")
     private Long idCalendarioEscolar;
 
-    @Size(max = 255)
-    private String faltas;
+    /**
+     * Tipo da frequência: PRESENTE, FALTA ou FALTA_JUSTIFICADA.
+     * Quando não informado, o serviço assume {@link TipoFrequencia#PRESENTE}.
+     */
+    private TipoFrequencia tipoFrequencia;
 
     public AlunoFrequenciaDTO() {}
 
+    /**
+     * Constrói o DTO a partir da entidade JPA.
+     *
+     * @param entity entidade persistida
+     */
     public AlunoFrequenciaDTO(AlunoFrequencia entity) {
         if (entity != null) {
-            BeanUtils.copyProperties(entity, this);
-            this.idAluno = entity.getPessoaAluno() != null ? entity.getPessoaAluno().getIdPessoa() : null;
-            this.idCalendarioEscolar = entity.getCalendarioEscolar() != null ? entity.getCalendarioEscolar().getIdCalendarioEscolar() : null;
+            this.idAlunoFrequencia = entity.getIdAlunoFrequencia();
+            this.tipoFrequencia = entity.getTipoFrequencia();
+            this.idAluno = entity.getPessoaAluno() != null
+                    ? entity.getPessoaAluno().getIdPessoa() : null;
+            this.idCalendarioEscolar = entity.getCalendarioEscolar() != null
+                    ? entity.getCalendarioEscolar().getIdCalendarioEscolar() : null;
         }
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/frequencia/dto/FrequenciaResumoDTO.java
+++ b/src/main/java/com/diario/de/classe/modules/frequencia/dto/FrequenciaResumoDTO.java
@@ -1,0 +1,29 @@
+package com.diario.de.classe.modules.frequencia.dto;
+
+/**
+ * DTO de resumo de frequência de um aluno.
+ *
+ * <p>Expõe as contagens e o percentual de presença calculado pelo serviço,
+ * além do indicador de risco de reprovação por frequência (LDB Art. 24 — mínimo 75%).
+ *
+ * @param idAluno            ID do aluno consultado
+ * @param totalAulas         Total de aulas registradas para o aluno (denominador da fórmula)
+ * @param totalPresencas     Quantidade de ocorrências com tipo {@code PRESENTE}
+ * @param totalFaltas        Quantidade de ocorrências com tipo {@code FALTA}
+ * @param totalFaltasJust    Quantidade de ocorrências com tipo {@code FALTA_JUSTIFICADA}
+ * @param percentualPresenca Percentual calculado: {@code (totalPresencas / totalAulas) * 100}.
+ *                           Retorna {@code 0.0} quando não há aulas registradas.
+ * @param emRiscoReprovacao  {@code true} quando {@code percentualPresenca < 75.0} (LDB)
+ */
+public record FrequenciaResumoDTO(
+        Long idAluno,
+        long totalAulas,
+        long totalPresencas,
+        long totalFaltas,
+        long totalFaltasJust,
+        double percentualPresenca,
+        boolean emRiscoReprovacao
+) {
+    /** Frequência mínima legal exigida pela LDB (Lei nº 9.394/96, Art. 24). */
+    public static final double FREQUENCIA_MINIMA_LDB = 75.0;
+}

--- a/src/main/java/com/diario/de/classe/modules/turma/AlunoTurmaController.java
+++ b/src/main/java/com/diario/de/classe/modules/turma/AlunoTurmaController.java
@@ -4,7 +4,6 @@ import com.diario.de.classe.modules.turma.dto.AlunoTurmaDTO;
 import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.beans.BeanUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -14,51 +13,63 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/v1/alunos-turma")
-@Tag(name = "AlunoTurma", description = "Gerenciamento de alunos por turma")
+@Tag(name = "AlunoTurma", description = "Consulta e gestão de matrículas individuais. Para matricular via turma, use POST /v1/turmas/{id}/alunos")
 public class AlunoTurmaController {
 
     private final AlunoTurmaService service;
 
     public AlunoTurmaController(AlunoTurmaService service) { this.service = service; }
 
-    @Operation(summary = "Listar todos os alunos por turma")
+    /**
+     * Lista todas as matrículas ativas do sistema.
+     * Registros desativados via soft delete não aparecem.
+     */
+    @Operation(summary = "Listar todas as matrículas ativas")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
     @GetMapping
     public ResponseEntity<ApiResponse<List<AlunoTurmaDTO>>> listar() {
         return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos().stream().map(AlunoTurmaDTO::new).toList()));
     }
 
-    @Operation(summary = "Buscar aluno-turma por ID")
+    /**
+     * Busca uma matrícula específica pelo ID.
+     */
+    @Operation(summary = "Buscar matrícula por ID")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<AlunoTurmaDTO>> buscarPorId(@PathVariable Long id) {
         return ResponseEntity.ok(ApiResponse.ok(new AlunoTurmaDTO(service.buscarPorId(id))));
     }
 
-    @Operation(summary = "Adicionar aluno à turma")
+    /**
+     * Matricula um aluno em uma turma.
+     *
+     * Aplica regra de negócio: aluno não pode estar matriculado na mesma turma
+     * duas vezes simultaneamente (lança HTTP 422 se ocorrer).
+     *
+     * Alternativa orientada a recursos: POST /v1/turmas/{id}/alunos.
+     */
+    @Operation(summary = "Matricular aluno em turma (com validação de duplicidade)")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @PostMapping
-    public ResponseEntity<ApiResponse<AlunoTurmaDTO>> criar(@RequestBody AlunoTurmaDTO dto) {
-        AlunoTurma entity = new AlunoTurma();
-        entity.setObs(dto.getObs());
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.ok(new AlunoTurmaDTO(service.criar(entity, dto.getIdAluno(), dto.getIdTurma())), "Aluno adicionado à turma com sucesso"));
+    public ResponseEntity<ApiResponse<AlunoTurmaDTO>> matricular(@RequestBody AlunoTurmaDTO dto) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(
+                new AlunoTurmaDTO(service.matricular(dto.getIdAluno(), dto.getIdTurma(), dto.getObs())),
+                "Aluno matriculado com sucesso"
+        ));
     }
 
-    @Operation(summary = "Atualizar aluno-turma")
-    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
-    @PutMapping("/{id}")
-    public ResponseEntity<ApiResponse<AlunoTurmaDTO>> atualizar(@PathVariable Long id, @RequestBody AlunoTurmaDTO dto) {
-        AlunoTurma dados = new AlunoTurma();
-        BeanUtils.copyProperties(dto, dados, "idAlunoTurma");
-        return ResponseEntity.ok(ApiResponse.ok(new AlunoTurmaDTO(service.atualizar(id, dados, dto.getIdAluno(), dto.getIdTurma()))));
-    }
-
-    @Operation(summary = "Remover aluno da turma")
+    /**
+     * Desativa uma matrícula (soft delete).
+     *
+     * O registro permanece no banco com ativo=false para manter o histórico pedagógico.
+     * Após desativar, o aluno pode ser rematriculado na mesma turma.
+     */
+    @Operation(summary = "Desativar matrícula (soft delete)")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @DeleteMapping("/{id}")
-    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
-        service.deletar(id);
-        return ResponseEntity.ok(ApiResponse.ok(null, "Excluído com sucesso"));
+    public ResponseEntity<ApiResponse<Void>> desativar(@PathVariable Long id) {
+        service.desativar(id);
+        return ResponseEntity.ok(ApiResponse.ok(null, "Matrícula desativada com sucesso"));
     }
 }

--- a/src/main/java/com/diario/de/classe/modules/turma/AlunoTurmaRepository.java
+++ b/src/main/java/com/diario/de/classe/modules/turma/AlunoTurmaRepository.java
@@ -1,8 +1,32 @@
 package com.diario.de.classe.modules.turma;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface AlunoTurmaRepository extends JpaRepository<AlunoTurma, Long> {
+
+    /**
+     * Lista todas as matrículas ativas, excluindo registros com soft delete.
+     * Usar sempre este método nas listagens gerais — nunca findAll() diretamente.
+     */
+    @Query("SELECT at FROM AlunoTurma at WHERE at.ativo = true")
+    List<AlunoTurma> findAllAtivos();
+
+    /**
+     * Lista as matrículas ativas de uma turma específica.
+     * Usado no endpoint GET /v1/turmas/{id}/alunos.
+     */
+    @Query("SELECT at FROM AlunoTurma at WHERE at.turma.idTurma = :idTurma AND at.ativo = true")
+    List<AlunoTurma> findAtivosByTurmaId(@Param("idTurma") Long idTurma);
+
+    /**
+     * Verifica se um aluno já está matriculado em uma turma (matrícula ativa).
+     * Usado para evitar matrículas duplicadas antes de persistir.
+     */
+    boolean existsByPessoaAlunoIdPessoaAndTurmaIdTurmaAndAtivoTrue(Long idPessoa, Long idTurma);
 }

--- a/src/main/java/com/diario/de/classe/modules/turma/AlunoTurmaService.java
+++ b/src/main/java/com/diario/de/classe/modules/turma/AlunoTurmaService.java
@@ -1,14 +1,17 @@
 package com.diario.de.classe.modules.turma;
 
+import com.diario.de.classe.modules.pessoa.Pessoa;
 import com.diario.de.classe.modules.pessoa.PessoaRepository;
+import com.diario.de.classe.shared.exception.BusinessException;
 import com.diario.de.classe.shared.exception.ResourceNotFoundException;
-import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
 public class AlunoTurmaService {
+
     private final AlunoTurmaRepository repository;
     private final PessoaRepository pessoaRepository;
     private final TurmaRepository turmaRepository;
@@ -20,30 +23,88 @@ public class AlunoTurmaService {
         this.turmaRepository = turmaRepository;
     }
 
-    public List<AlunoTurma> buscarTodos() { return repository.findAll(); }
+    /**
+     * Lista todas as matrículas ativas do sistema.
+     * Registros com soft delete (ativo=false) são excluídos automaticamente.
+     */
+    public List<AlunoTurma> buscarTodos() {
+        return repository.findAllAtivos();
+    }
 
+    /**
+     * Busca uma matrícula pelo ID.
+     *
+     * @throws ResourceNotFoundException se a matrícula não existir
+     */
     public AlunoTurma buscarPorId(Long id) {
         return repository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException("AlunoTurma não encontrado com id: " + id));
+                .orElseThrow(() -> new ResourceNotFoundException("Matrícula não encontrada com id: " + id));
     }
 
-    public AlunoTurma criar(AlunoTurma alunoTurma, Long idAluno, Long idTurma) {
-        alunoTurma.setPessoaAluno(pessoaRepository.findById(idAluno)
-                .orElseThrow(() -> new ResourceNotFoundException("Aluno não encontrado com id: " + idAluno)));
-        alunoTurma.setTurma(turmaRepository.findById(idTurma)
-                .orElseThrow(() -> new ResourceNotFoundException("Turma não encontrada com id: " + idTurma)));
-        return repository.save(alunoTurma);
+    /**
+     * Lista todos os alunos ativamente matriculados em uma turma.
+     *
+     * @param idTurma ID da turma
+     * @return lista de matrículas ativas da turma
+     * @throws ResourceNotFoundException se a turma não existir
+     */
+    public List<AlunoTurma> buscarAlunosPorTurma(Long idTurma) {
+        if (!turmaRepository.existsById(idTurma)) {
+            throw new ResourceNotFoundException("Turma não encontrada com id: " + idTurma);
+        }
+        return repository.findAtivosByTurmaId(idTurma);
     }
 
-    public AlunoTurma atualizar(Long id, AlunoTurma dados, Long idAluno, Long idTurma) {
-        AlunoTurma existente = buscarPorId(id);
-        BeanUtils.copyProperties(dados, existente, "idAlunoTurma", "createdAt", "pessoaAluno", "turma");
-        if (idAluno != null) existente.setPessoaAluno(pessoaRepository.findById(idAluno)
-                .orElseThrow(() -> new ResourceNotFoundException("Aluno não encontrado com id: " + idAluno)));
-        if (idTurma != null) existente.setTurma(turmaRepository.findById(idTurma)
-                .orElseThrow(() -> new ResourceNotFoundException("Turma não encontrada com id: " + idTurma)));
-        return repository.save(existente);
+    /**
+     * Matricula um aluno em uma turma, aplicando as regras de negócio.
+     *
+     * Regras:
+     * - O aluno (Pessoa) deve existir no banco.
+     * - A turma deve existir no banco.
+     * - O aluno não pode estar matriculado na mesma turma mais de uma vez simultaneamente.
+     *   Matrículas desativadas (soft delete) não bloqueiam uma nova matrícula.
+     *
+     * @param idAluno ID da Pessoa do tipo ALUNO
+     * @param idTurma ID da Turma
+     * @param obs     Observação opcional sobre a matrícula
+     * @return matrícula persistida
+     * @throws ResourceNotFoundException se aluno ou turma não forem encontrados
+     * @throws BusinessException         se o aluno já estiver matriculado ativamente nesta turma
+     */
+    public AlunoTurma matricular(Long idAluno, Long idTurma, String obs) {
+        Pessoa aluno = pessoaRepository.findById(idAluno)
+                .orElseThrow(() -> new ResourceNotFoundException("Aluno não encontrado com id: " + idAluno));
+
+        Turma turma = turmaRepository.findById(idTurma)
+                .orElseThrow(() -> new ResourceNotFoundException("Turma não encontrada com id: " + idTurma));
+
+        // Impede matrícula duplicada — verifica apenas matrículas ativas (ativo=true)
+        if (repository.existsByPessoaAlunoIdPessoaAndTurmaIdTurmaAndAtivoTrue(idAluno, idTurma)) {
+            throw new BusinessException(
+                    "Aluno já está matriculado nesta turma. Desative a matrícula atual antes de criar uma nova.");
+        }
+
+        AlunoTurma matricula = new AlunoTurma();
+        matricula.setPessoaAluno(aluno);
+        matricula.setTurma(turma);
+        matricula.setObs(obs);
+
+        return repository.save(matricula);
     }
 
-    public void deletar(Long id) { repository.delete(buscarPorId(id)); }
+    /**
+     * Desativa uma matrícula (soft delete).
+     *
+     * O histórico de matrícula é preservado no banco para fins pedagógicos e legais.
+     * Nunca usar repository.delete() diretamente — sempre chamar este método.
+     *
+     * @param id ID da matrícula a desativar
+     * @throws ResourceNotFoundException se a matrícula não existir
+     */
+    public void desativar(Long id) {
+        AlunoTurma matricula = buscarPorId(id);
+        matricula.setAtivo(false);
+        matricula.setDeletedAt(LocalDateTime.now());
+        repository.save(matricula);
+    }
 }

--- a/src/main/java/com/diario/de/classe/modules/turma/TurmaController.java
+++ b/src/main/java/com/diario/de/classe/modules/turma/TurmaController.java
@@ -1,5 +1,6 @@
 package com.diario.de.classe.modules.turma;
 
+import com.diario.de.classe.modules.turma.dto.AlunoTurmaDTO;
 import com.diario.de.classe.modules.turma.dto.TurmaDTO;
 import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,12 +15,16 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/v1/turmas")
-@Tag(name = "Turma", description = "Gerenciamento de turmas")
+@Tag(name = "Turma", description = "Gerenciamento de turmas e matrículas de alunos")
 public class TurmaController {
 
     private final TurmaService service;
+    private final AlunoTurmaService alunoTurmaService;
 
-    public TurmaController(TurmaService service) { this.service = service; }
+    public TurmaController(TurmaService service, AlunoTurmaService alunoTurmaService) {
+        this.service = service;
+        this.alunoTurmaService = alunoTurmaService;
+    }
 
     @Operation(summary = "Listar todas as turmas")
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
@@ -59,5 +64,48 @@ public class TurmaController {
     public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
         service.deletar(id);
         return ResponseEntity.ok(ApiResponse.ok(null, "Excluído com sucesso"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Endpoints de matrícula — alunos de uma turma
+    // -------------------------------------------------------------------------
+
+    /**
+     * Lista todos os alunos ativamente matriculados em uma turma.
+     *
+     * Retorna apenas matrículas com ativo=true — histórico de ex-alunos não aparece.
+     *
+     * @param id ID da turma
+     * @return lista de matrículas ativas da turma
+     */
+    @Operation(summary = "Listar alunos matriculados na turma")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
+    @GetMapping("/{id}/alunos")
+    public ResponseEntity<ApiResponse<List<AlunoTurmaDTO>>> listarAlunos(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(
+                alunoTurmaService.buscarAlunosPorTurma(id).stream().map(AlunoTurmaDTO::new).toList()
+        ));
+    }
+
+    /**
+     * Matricula um aluno na turma.
+     *
+     * Aplica regra de negócio: um aluno não pode ter duas matrículas ativas
+     * na mesma turma simultaneamente (retorna HTTP 422 se ocorrer).
+     *
+     * @param id  ID da turma
+     * @param dto DTO com idAluno e obs (observação opcional)
+     * @return matrícula criada
+     */
+    @Operation(summary = "Matricular aluno na turma (com validação de duplicidade)")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
+    @PostMapping("/{id}/alunos")
+    public ResponseEntity<ApiResponse<AlunoTurmaDTO>> matricular(
+            @PathVariable Long id,
+            @RequestBody AlunoTurmaDTO dto) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(
+                new AlunoTurmaDTO(alunoTurmaService.matricular(dto.getIdAluno(), id, dto.getObs())),
+                "Aluno matriculado com sucesso"
+        ));
     }
 }

--- a/src/main/resources/db/migration/V8__alter_frequencia_add_tipo.sql
+++ b/src/main/resources/db/migration/V8__alter_frequencia_add_tipo.sql
@@ -1,0 +1,15 @@
+-- =============================================================================
+-- V8 — Ajuste na tabela aluno_frequencia: substituir 'faltas' por 'tipo_frequencia'
+--
+-- Motivo: a coluna 'faltas' (VARCHAR) não refletia o modelo correto.
+-- Cada registro deve representar a ocorrência de UM aluno em UMA aula,
+-- com o tipo: PRESENTE, FALTA ou FALTA_JUSTIFICADA (LDB Art. 24).
+-- =============================================================================
+
+-- Adiciona a nova coluna com valor padrão PRESENTE para registros existentes.
+ALTER TABLE aluno_frequencia
+    ADD COLUMN tipo_frequencia VARCHAR(30) NOT NULL DEFAULT 'PRESENTE';
+
+-- Remove a coluna legada que não mais representa o modelo.
+ALTER TABLE aluno_frequencia
+    DROP COLUMN faltas;


### PR DESCRIPTION
ETAPA 6 — foi executada na sessão anterior (antes do resumo de contexto). Implementou o fluxo de matrícula de alunos: AlunoTurmaRepository com queries de duplicidade, AlunoTurmaService com regra de negócio (matricular, soft delete), AlunoTurmaController atualizado, e dois novos endpoints em TurmaController (GET/POST /v1/turmas/{id}/alunos).

ETAPA 7 — foi executada agora nesta sessão. Implementou o lançamento de frequência com cálculo LDB 75%.