### PR TITLE
configure SpringDoc OpenAPI and add @Operation to all endpoints

### DIFF
--- a/src/main/java/com/diario/de/classe/config/OpenApiConfig.java
+++ b/src/main/java/com/diario/de/classe/config/OpenApiConfig.java
@@ -1,0 +1,87 @@
+package com.diario.de.classe.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuração do SpringDoc/OpenAPI para o projeto DiárioDigital.
+ *
+ * <p>Gera documentação interativa acessível em:
+ * <ul>
+ *   <li>Swagger UI: {@code /swagger-ui.html}</li>
+ *   <li>JSON OpenAPI: {@code /v3/api-docs}</li>
+ * </ul>
+ *
+ * <p><strong>Autenticação no Swagger UI:</strong>
+ * A API usa cookie HttpOnly ({@code auth_token}).
+ * Para testar endpoints protegidos:
+ * <ol>
+ *   <li>Chame {@code POST /v1/auth/login} através do Swagger UI.</li>
+ *   <li>O browser armazenará o cookie automaticamente.</li>
+ *   <li>Todas as chamadas subsequentes incluirão o cookie.</li>
+ * </ol>
+ */
+@Configuration
+public class OpenApiConfig {
+
+    /**
+     * Configuração principal da API: título, descrição, versão, contato e esquema de segurança.
+     *
+     * <p>O esquema {@code cookieAuth} indica que a autenticação usa o cookie
+     * {@code auth_token} gerado pelo endpoint de login.
+     */
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("DiárioDigital API")
+                        .description("""
+                                Backend da plataforma **DiárioDigital** — sistema de gestão escolar
+                                para a rede municipal de Cruzeiro/SP.
+
+                                ### Autenticação
+                                A API usa **JWT em cookie HttpOnly** (`auth_token`).
+                                Para testar endpoints protegidos no Swagger UI:
+                                1. Execute `POST /v1/auth/login` com suas credenciais.
+                                2. O cookie será definido automaticamente no browser.
+                                3. As chamadas subsequentes serão autenticadas automaticamente.
+
+                                ### Controle de Acesso (RBAC)
+                                Perfis disponíveis (em ordem de privilégio):
+                                `ADMINISTRADOR > DIRETOR > COORDENADOR > PROFESSOR > RESPONSAVEL > ALUNO`
+                                """)
+                        .version("1.0.0")
+                        .contact(new Contact()
+                                .name("DiárioDigital")
+                                .email("contato@diariodigital.com.br")))
+                // Aplica o esquema de segurança globalmente a todos os endpoints
+                .addSecurityItem(new SecurityRequirement().addList("cookieAuth"))
+                .components(new Components()
+                        .addSecuritySchemes("cookieAuth", new SecurityScheme()
+                                .type(SecurityScheme.Type.APIKEY)
+                                .in(SecurityScheme.In.COOKIE)
+                                .name("auth_token")
+                                .description(
+                                        "Token JWT armazenado em cookie HttpOnly. " +
+                                        "Faça login em `POST /v1/auth/login` para receber o cookie.")));
+    }
+
+    /**
+     * Agrupa todos os endpoints sob o prefixo {@code /v1}.
+     * Útil para versionar a API futuramente.
+     */
+    @Bean
+    public GroupedOpenApi v1Api() {
+        return GroupedOpenApi.builder()
+                .group("v1")
+                .pathsToMatch("/v1/**")
+                .build();
+    }
+}

--- a/src/main/java/com/diario/de/classe/modules/auth/AuthController.java
+++ b/src/main/java/com/diario/de/classe/modules/auth/AuthController.java
@@ -3,6 +3,8 @@ package com.diario.de.classe.modules.auth;
 import com.diario.de.classe.modules.auth.dto.UserMeResponse;
 import com.diario.de.classe.shared.dto.ApiResponse;
 import com.diario.de.classe.shared.security.JwtService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -13,14 +15,17 @@ import org.springframework.web.bind.annotation.*;
 /**
  * Controller de autenticação: registro, login, logout e dados do usuário logado.
  *
- * Rotas públicas (liberadas no SecurityConfig):
- *   POST /v1/auth/register
- *   POST /v1/auth/login
- *   POST /v1/auth/logout
- *   GET  /v1/auth/me
+ * <p>Rotas públicas (liberadas no SecurityConfig):
+ * <ul>
+ *   <li>{@code POST /v1/auth/register} — cria novo usuário</li>
+ *   <li>{@code POST /v1/auth/login} — autentica e emite cookie JWT</li>
+ *   <li>{@code POST /v1/auth/logout} — invalida o cookie</li>
+ *   <li>{@code GET  /v1/auth/me} — dados do usuário autenticado</li>
+ * </ul>
  */
 @RestController
 @RequestMapping("/v1/auth")
+@Tag(name = "Autenticação", description = "Login, registro, logout e consulta do usuário autenticado")
 public class AuthController {
 
     private final UserRepository userRepository;
@@ -35,11 +40,18 @@ public class AuthController {
 
     /**
      * Registra um novo usuário, codificando a senha antes de persistir.
-     * A entidade User não é exposta diretamente — retorna apenas confirmação.
      *
-     * @param user Dados do usuário (nome, email, senha, role)
-     * @return Confirmação de registro sem expor dados sensíveis
+     * <p>A entidade {@code User} não é exposta na resposta para evitar
+     * vazamento de dados sensíveis.
+     *
+     * @param user dados do usuário (nome, email, senha, role)
+     * @return confirmação de registro
      */
+    @Operation(
+            summary = "Registrar novo usuário",
+            description = "Cria um novo usuário no sistema. A senha é armazenada com BCrypt. " +
+                          "Não retorna o usuário criado para evitar exposição de dados sensíveis."
+    )
     @PostMapping("/register")
     public ResponseEntity<ApiResponse<Void>> register(@RequestBody User user) {
         user.setSenha(passwordEncoder.encode(user.getSenha()));
@@ -50,12 +62,32 @@ public class AuthController {
     /**
      * Autentica o usuário e emite um token JWT em cookie HttpOnly.
      *
-     * O cookie HttpOnly impede acesso via JavaScript, protegendo contra ataques XSS.
-     * Duração do cookie: 1 dia.
+     * <p>O cookie HttpOnly impede acesso via JavaScript, protegendo contra ataques XSS.
+     * Duração do cookie: 1 dia (86.400 segundos).
      *
-     * @param user     Credenciais (email + senha)
-     * @param response Resposta HTTP onde o cookie será adicionado
+     * <p>Após o login bem-sucedido no Swagger UI, o browser armazena o cookie
+     * automaticamente e todas as chamadas subsequentes serão autenticadas.
+     *
+     * @param user     credenciais de acesso (email + senha)
+     * @param response resposta HTTP onde o cookie {@code auth_token} será definido
+     * @return confirmação de login (o token fica no cookie, não no body)
      */
+    @Operation(
+            summary = "Fazer login",
+            description = """
+                    Autentica com email e senha. Em caso de sucesso, define o cookie **auth_token** (HttpOnly).
+
+                    **Como usar no Swagger UI:**
+                    1. Execute este endpoint com suas credenciais.
+                    2. O browser armazenará o cookie automaticamente.
+                    3. Os demais endpoints já estarão autenticados.
+
+                    **Corpo esperado:**
+                    ```json
+                    { "email": "usuario@exemplo.com", "senha": "minhasenha" }
+                    ```
+                    """
+    )
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<Void>> login(@RequestBody User user, HttpServletResponse response) {
         var userFromDb = userRepository.findByEmail(user.getEmail())
@@ -79,8 +111,16 @@ public class AuthController {
     }
 
     /**
-     * Encerra a sessão do usuário limpando o cookie de autenticação.
+     * Encerra a sessão do usuário zerando o cookie de autenticação.
+     *
+     * <p>Define o cookie {@code auth_token} com {@code maxAge=0}, fazendo o browser
+     * descartá-lo imediatamente. O token não é invalidado no servidor (stateless JWT).
      */
+    @Operation(
+            summary = "Fazer logout",
+            description = "Encerra a sessão zerando o cookie auth_token no browser. " +
+                          "O token JWT não é invalidado no servidor (design stateless)."
+    )
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(HttpServletResponse response) {
         Cookie cookie = new Cookie("auth_token", null);
@@ -96,9 +136,13 @@ public class AuthController {
     /**
      * Retorna os dados do usuário atualmente autenticado, lidos a partir do token JWT.
      *
-     * @param request Requisição com o cookie auth_token
-     * @return Dados básicos do usuário (id, email, nome, role)
+     * @param request requisição com o cookie auth_token
+     * @return dados básicos do usuário: id, email, nome e role
      */
+    @Operation(
+            summary = "Dados do usuário autenticado",
+            description = "Retorna id, email, nome e role do usuário identificado pelo cookie auth_token."
+    )
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<UserMeResponse>> me(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();

--- a/src/main/java/com/diario/de/classe/modules/avaliacao/AlunoNotasController.java
+++ b/src/main/java/com/diario/de/classe/modules/avaliacao/AlunoNotasController.java
@@ -4,6 +4,7 @@ import com.diario.de.classe.modules.avaliacao.dto.AlunoAvaliacaoDTO;
 import com.diario.de.classe.modules.avaliacao.dto.BoletimResponseDTO;
 import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -45,6 +46,10 @@ public class AlunoNotasController {
             description = "Retorna todas as notas ativas registradas para o aluno. " +
                           "Para médias e situação por disciplina, use GET /v1/alunos/{id}/boletim."
     )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Lista de notas retornada com sucesso"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Aluno não encontrado")
+    })
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR', 'ALUNO', 'RESPONSAVEL')")
     @GetMapping("/{id}/notas")
     public ResponseEntity<ApiResponse<List<AlunoAvaliacaoDTO>>> listarNotas(@PathVariable Long id) {
@@ -76,6 +81,10 @@ public class AlunoNotasController {
                     - Situação: APROVADO, EM_RECUPERACAO, REPROVADO_NOTA ou REPROVADO_FREQUENCIA
                     """
     )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Boletim gerado com sucesso"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Aluno não encontrado")
+    })
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR', 'ALUNO', 'RESPONSAVEL')")
     @GetMapping("/{id}/boletim")
     public ResponseEntity<ApiResponse<BoletimResponseDTO>> boletim(@PathVariable Long id) {

--- a/src/main/java/com/diario/de/classe/modules/avaliacao/AvaliacaoController.java
+++ b/src/main/java/com/diario/de/classe/modules/avaliacao/AvaliacaoController.java
@@ -5,6 +5,7 @@ import com.diario.de.classe.modules.avaliacao.dto.AvaliacaoDTO;
 import com.diario.de.classe.modules.avaliacao.dto.NotaLancamentoDTO;
 import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -130,9 +131,14 @@ public class AvaliacaoController {
             description = """
                     Registra a nota de múltiplos alunos para uma mesma avaliação em uma única requisição.
                     A operação é transacional: qualquer erro cancela todos os lançamentos.
-                    Retorna HTTP 422 se algum aluno já tiver nota ativa nesta avaliação.
                     """
     )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Notas lançadas com sucesso"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Avaliação ou aluno não encontrado"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "422", description = "Algum aluno já possui nota ativa nesta avaliação"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Perfil sem permissão (requer ADMINISTRADOR ou PROFESSOR)")
+    })
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'PROFESSOR')")
     @PostMapping("/{id}/notas")
     public ResponseEntity<ApiResponse<List<AlunoAvaliacaoDTO>>> lancarNotas(

--- a/src/main/java/com/diario/de/classe/modules/frequencia/AlunoFrequenciaController.java
+++ b/src/main/java/com/diario/de/classe/modules/frequencia/AlunoFrequenciaController.java
@@ -4,6 +4,7 @@ import com.diario.de.classe.modules.frequencia.dto.AlunoFrequenciaDTO;
 import com.diario.de.classe.modules.frequencia.dto.FrequenciaResumoDTO;
 import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -150,6 +151,12 @@ public class AlunoFrequenciaController {
      * @return lista de registros criados neste lançamento
      */
     @Operation(summary = "Lançar frequência em lote para toda a turma")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Frequência lançada com sucesso"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Turma ou calendário não encontrado"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "422", description = "Nenhum aluno matriculado na turma"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Perfil sem permissão (requer ADMINISTRADOR ou PROFESSOR)")
+    })
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'PROFESSOR')")
     @PostMapping("/turma/{idTurma}/calendario/{idCalendario}")
     public ResponseEntity<ApiResponse<List<AlunoFrequenciaDTO>>> registrarTurma(

--- a/src/main/java/com/diario/de/classe/modules/turma/TurmaController.java
+++ b/src/main/java/com/diario/de/classe/modules/turma/TurmaController.java
@@ -4,6 +4,7 @@ import com.diario.de.classe.modules.turma.dto.AlunoTurmaDTO;
 import com.diario.de.classe.modules.turma.dto.TurmaDTO;
 import com.diario.de.classe.shared.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.BeanUtils;
 import org.springframework.http.HttpStatus;
@@ -98,6 +99,12 @@ public class TurmaController {
      * @return matrícula criada
      */
     @Operation(summary = "Matricular aluno na turma (com validação de duplicidade)")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Aluno matriculado com sucesso"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Turma ou aluno não encontrado"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "422", description = "Aluno já possui matrícula ativa nesta turma"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Perfil sem permissão (requer ADMINISTRADOR ou COORDENADOR)")
+    })
     @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
     @PostMapping("/{id}/alunos")
     public ResponseEntity<ApiResponse<AlunoTurmaDTO>> matricular(

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,3 +22,20 @@ geral.erro.nao.encontrado.msg=Nenhum registro encontrado.
 geral.erro.criar.msg=Erro ao tentar criar.
 geral.erro.atualizar.msg=Erro ao tentar atualizar.
 usuario.erro.nao.encontrado.msg=Nenhum usuario encontrado.
+
+# ============================================================
+# SpringDoc / Swagger UI
+# ============================================================
+# URL da interface interativa: /swagger-ui.html
+springdoc.swagger-ui.path=/swagger-ui.html
+# URL do JSON de especificacao OpenAPI: /v3/api-docs
+springdoc.api-docs.path=/v3/api-docs
+# Ordena operacoes e tags alfabeticamente no Swagger UI
+springdoc.swagger-ui.operationsSorter=alpha
+springdoc.swagger-ui.tagsSorter=alpha
+# Habilita o botao "Try it out" por padrao em todos os endpoints
+springdoc.swagger-ui.try-it-out-enabled=true
+# Exibe a duracao da requisicao apos execucao
+springdoc.swagger-ui.display-request-duration=true
+# Formato de resposta padrao
+springdoc.default-produces-media-type=application/json


### PR DESCRIPTION
ETAPA 9 concluída. Resumo:

Arquivos criados:

Arquivo	Propósito
config/OpenApiConfig.java	Info da API (título, descrição, versão) + esquema cookieAuth + group v1
Arquivos modificados:

Arquivo	O que mudou
application.properties	7 propriedades springdoc: path, sorting, try-it-out, display-duration
AuthController.java	@Tag + @Operation com descrição detalhada em todos os 4 endpoints
AvaliacaoController.java	@ApiResponses no POST /{id}/notas (201, 403, 404, 422)
TurmaController.java	@ApiResponses no POST /{id}/alunos (201, 403, 404, 422)
AlunoFrequenciaController.java	@ApiResponses no POST /turma/{id}/calendario/{id} (201, 403, 404, 422)
AlunoNotasController.java	@ApiResponses no GET /{id}/notas e GET /{id}/boletim (200, 404)
Swagger UI acessível em: /swagger-ui.html — ordenado alfabeticamente, com "Try it out" habilitado por padrão. Para testar endpoints protegidos: faça POST /v1/auth/login no Swagger UI e o cookie é setado automaticamente pelo browser.