### PR TITLE
feat: adiciona DTOs, Services e Controllers do módulo cronograma

### DIFF
--- a/src/main/java/com/diario/de/classe/modules/cronograma/AulaController.java
+++ b/src/main/java/com/diario/de/classe/modules/cronograma/AulaController.java
@@ -1,0 +1,121 @@
+package com.diario.de.classe.modules.cronograma;
+
+import com.diario.de.classe.modules.cronograma.dto.AulaDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/aulas")
+@Tag(name = "Aula", description = "Registro de aulas — ocorrência concreta de aula vinculada a um período letivo")
+public class AulaController {
+
+    private final AulaService service;
+
+    public AulaController(AulaService service) {
+        this.service = service;
+    }
+
+    @Operation(summary = "Listar todas as aulas")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<AulaDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos()));
+    }
+
+    @Operation(summary = "Buscar aula por ID")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<AulaDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarPorId(id)));
+    }
+
+    @Operation(summary = "Listar aulas de uma classe em uma data específica")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
+    @GetMapping("/classe/{idClasse}/data/{data}")
+    public ResponseEntity<ApiResponse<List<AulaDTO>>> buscarPorClasseEData(
+            @PathVariable Long idClasse,
+            @PathVariable @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate data) {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarPorClasseEData(idClasse, data)));
+    }
+
+    @Operation(summary = "Listar aulas de uma classe em um período letivo")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
+    @GetMapping("/periodo/{idPeriodo}/classe/{idClasse}")
+    public ResponseEntity<ApiResponse<List<AulaDTO>>> buscarPorPeriodoEClasse(
+            @PathVariable Long idPeriodo,
+            @PathVariable Long idClasse) {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarPorPeriodoEClasse(idPeriodo, idClasse)));
+    }
+
+    @Operation(
+            summary = "Registrar nova aula",
+            description = """
+                    Registra uma aula para a classe e período letivo informados.
+                    A data deve estar dentro do intervalo do período letivo.
+                    Não é permitido registrar duas aulas com o mesmo número na mesma data e classe.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Aula registrada com sucesso"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Classe, período letivo ou professor não encontrado"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "422", description = "Aula duplicada ou data fora do período letivo"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Perfil sem permissão (requer ADMINISTRADOR ou PROFESSOR)")
+    })
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'PROFESSOR')")
+    @PostMapping
+    public ResponseEntity<ApiResponse<AulaDTO>> criar(@RequestBody AulaDTO dto) {
+        Aula entity = new Aula();
+        entity.setDataAula(dto.getDataAula());
+        entity.setNumeroAula(dto.getNumeroAula());
+        entity.setConteudoMinistrado(dto.getConteudoMinistrado());
+        entity.setChamadaEncerrada(dto.getChamadaEncerrada() != null ? dto.getChamadaEncerrada() : false);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.ok(
+                        service.criar(entity, dto.getIdClasse(), dto.getIdPeriodoLetivo(), dto.getIdRegistradoPor()),
+                        "Aula registrada com sucesso"));
+    }
+
+    @Operation(summary = "Atualizar dados da aula",
+               description = "Não é possível alterar uma aula com chamada já encerrada.")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'PROFESSOR')")
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse<AulaDTO>> atualizar(
+            @PathVariable Long id, @RequestBody AulaDTO dto) {
+        Aula dados = new Aula();
+        dados.setDataAula(dto.getDataAula());
+        dados.setNumeroAula(dto.getNumeroAula());
+        dados.setConteudoMinistrado(dto.getConteudoMinistrado());
+        return ResponseEntity.ok(ApiResponse.ok(service.atualizar(id, dados)));
+    }
+
+    @Operation(summary = "Encerrar chamada da aula",
+               description = "Após encerrar, a chamada não pode mais ser alterada.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Chamada encerrada com sucesso"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "422", description = "Chamada já encerrada anteriormente")
+    })
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'PROFESSOR')")
+    @PatchMapping("/{id}/encerrar")
+    public ResponseEntity<ApiResponse<AulaDTO>> encerrarChamada(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(service.encerrarChamada(id), "Chamada encerrada com sucesso"));
+    }
+
+    @Operation(summary = "Desativar aula (soft delete)",
+               description = "Não é possível excluir uma aula com chamada já encerrada.")
+    @PreAuthorize("hasRole('ADMINISTRADOR')")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
+        service.deletar(id);
+        return ResponseEntity.ok(ApiResponse.ok(null, "Aula desativada com sucesso"));
+    }
+}

--- a/src/main/java/com/diario/de/classe/modules/cronograma/AulaService.java
+++ b/src/main/java/com/diario/de/classe/modules/cronograma/AulaService.java
@@ -1,0 +1,133 @@
+package com.diario.de.classe.modules.cronograma;
+
+import com.diario.de.classe.modules.cronograma.dto.AulaDTO;
+import com.diario.de.classe.modules.pessoa.Pessoa;
+import com.diario.de.classe.modules.pessoa.PessoaRepository;
+import com.diario.de.classe.modules.turma.Classe;
+import com.diario.de.classe.modules.turma.ClasseRepository;
+import com.diario.de.classe.shared.exception.BusinessException;
+import com.diario.de.classe.shared.exception.ResourceNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class AulaService {
+
+    private final AulaRepository repository;
+    private final ClasseRepository classeRepository;
+    private final PeriodoLetivoRepository periodoLetivoRepository;
+    private final PessoaRepository pessoaRepository;
+
+    public AulaService(AulaRepository repository,
+                       ClasseRepository classeRepository,
+                       PeriodoLetivoRepository periodoLetivoRepository,
+                       PessoaRepository pessoaRepository) {
+        this.repository = repository;
+        this.classeRepository = classeRepository;
+        this.periodoLetivoRepository = periodoLetivoRepository;
+        this.pessoaRepository = pessoaRepository;
+    }
+
+    public List<AulaDTO> buscarTodos() {
+        return repository.findAll().stream().map(AulaDTO::new).toList();
+    }
+
+    public AulaDTO buscarPorId(Long id) {
+        return new AulaDTO(repository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Aula não encontrada com id: " + id)));
+    }
+
+    public List<AulaDTO> buscarPorClasseEData(Long idClasse, LocalDate data) {
+        return repository.findByClasse_IdClasseAndDataAula(idClasse, data)
+                .stream().map(AulaDTO::new).toList();
+    }
+
+    public List<AulaDTO> buscarPorPeriodoEClasse(Long idPeriodo, Long idClasse) {
+        return repository.findByPeriodoLetivo_IdPeriodoLetivoAndClasse_IdClasse(idPeriodo, idClasse)
+                .stream().map(AulaDTO::new).toList();
+    }
+
+    @Transactional
+    public AulaDTO criar(Aula dados, Long idClasse, Long idPeriodo, Long idRegistradoPor) {
+        Classe classe = classeRepository.findById(idClasse)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Classe não encontrada com id: " + idClasse));
+
+        PeriodoLetivo periodo = periodoLetivoRepository.findById(idPeriodo)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Período letivo não encontrado com id: " + idPeriodo));
+
+        Pessoa registradoPor = pessoaRepository.findById(idRegistradoPor)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Pessoa não encontrada com id: " + idRegistradoPor));
+
+        if (repository.existsByClasse_IdClasseAndDataAulaAndNumeroAula(
+                idClasse, dados.getDataAula(), dados.getNumeroAula())) {
+            throw new BusinessException(
+                    "Já existe uma aula registrada para esta classe na data "
+                    + dados.getDataAula() + ", número " + dados.getNumeroAula() + ".");
+        }
+
+        LocalDate dataAula = dados.getDataAula();
+        if (dataAula.isBefore(periodo.getDataInicio()) || dataAula.isAfter(periodo.getDataFim())) {
+            throw new BusinessException(
+                    "A data da aula deve estar dentro do período letivo ("
+                    + periodo.getDataInicio() + " — " + periodo.getDataFim() + ").");
+        }
+
+        dados.setClasse(classe);
+        dados.setPeriodoLetivo(periodo);
+        dados.setRegistradoPor(registradoPor);
+
+        return new AulaDTO(repository.save(dados));
+    }
+
+    @Transactional
+    public AulaDTO encerrarChamada(Long idAula) {
+        Aula aula = repository.findById(idAula)
+                .orElseThrow(() -> new ResourceNotFoundException("Aula não encontrada com id: " + idAula));
+
+        if (Boolean.TRUE.equals(aula.getChamadaEncerrada())) {
+            throw new BusinessException("A chamada desta aula já foi encerrada.");
+        }
+
+        aula.setChamadaEncerrada(true);
+        return new AulaDTO(repository.save(aula));
+    }
+
+    @Transactional
+    public AulaDTO atualizar(Long id, Aula dados) {
+        Aula existente = repository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Aula não encontrada com id: " + id));
+
+        if (Boolean.TRUE.equals(existente.getChamadaEncerrada())) {
+            throw new BusinessException(
+                    "Não é possível alterar uma aula com chamada já encerrada.");
+        }
+
+        existente.setDataAula(dados.getDataAula());
+        existente.setNumeroAula(dados.getNumeroAula());
+        existente.setConteudoMinistrado(dados.getConteudoMinistrado());
+
+        return new AulaDTO(repository.save(existente));
+    }
+
+    @Transactional
+    public void deletar(Long id) {
+        Aula existente = repository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Aula não encontrada com id: " + id));
+
+        if (Boolean.TRUE.equals(existente.getChamadaEncerrada())) {
+            throw new BusinessException(
+                    "Não é possível excluir uma aula com chamada já encerrada.");
+        }
+
+        existente.setAtivo(false);
+        existente.setDeletedAt(LocalDateTime.now());
+        repository.save(existente);
+    }
+}

--- a/src/main/java/com/diario/de/classe/modules/cronograma/ClasseCronogramaController.java
+++ b/src/main/java/com/diario/de/classe/modules/cronograma/ClasseCronogramaController.java
@@ -1,0 +1,74 @@
+package com.diario.de.classe.modules.cronograma;
+
+import com.diario.de.classe.modules.cronograma.dto.ClasseCronogramaDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/classes-cronograma")
+@Tag(name = "ClasseCronograma", description = "Vínculo entre Classe e CronogramaAnual")
+public class ClasseCronogramaController {
+
+    private final ClasseCronogramaService service;
+
+    public ClasseCronogramaController(ClasseCronogramaService service) {
+        this.service = service;
+    }
+
+    @Operation(summary = "Listar todos os vínculos classe-cronograma")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<ClasseCronogramaDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos()));
+    }
+
+    @Operation(summary = "Buscar vínculo por ID")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<ClasseCronogramaDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarPorId(id)));
+    }
+
+    @Operation(summary = "Listar cronogramas vinculados a uma classe")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
+    @GetMapping("/classe/{idClasse}")
+    public ResponseEntity<ApiResponse<List<ClasseCronogramaDTO>>> buscarPorClasse(
+            @PathVariable Long idClasse) {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarPorClasse(idClasse)));
+    }
+
+    @Operation(summary = "Listar classes vinculadas a um cronograma")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
+    @GetMapping("/cronograma/{idCronograma}")
+    public ResponseEntity<ApiResponse<List<ClasseCronogramaDTO>>> buscarPorCronograma(
+            @PathVariable Long idCronograma) {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarPorCronograma(idCronograma)));
+    }
+
+    @Operation(summary = "Vincular classe a um cronograma anual",
+               description = "Corpo: { \"idClasse\": 1, \"idCronogramaAnual\": 2 }")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
+    @PostMapping
+    public ResponseEntity<ApiResponse<ClasseCronogramaDTO>> vincular(
+            @RequestBody ClasseCronogramaDTO dto) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.ok(
+                        service.vincular(dto.getIdClasse(), dto.getIdCronogramaAnual()),
+                        "Classe vinculada ao cronograma com sucesso"));
+    }
+
+    @Operation(summary = "Desvincular classe do cronograma (soft delete)")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> desvincular(@PathVariable Long id) {
+        service.desvincular(id);
+        return ResponseEntity.ok(ApiResponse.ok(null, "Vínculo desativado com sucesso"));
+    }
+}

--- a/src/main/java/com/diario/de/classe/modules/cronograma/ClasseCronogramaService.java
+++ b/src/main/java/com/diario/de/classe/modules/cronograma/ClasseCronogramaService.java
@@ -1,0 +1,80 @@
+package com.diario.de.classe.modules.cronograma;
+
+import com.diario.de.classe.modules.cronograma.dto.ClasseCronogramaDTO;
+import com.diario.de.classe.modules.turma.Classe;
+import com.diario.de.classe.modules.turma.ClasseRepository;
+import com.diario.de.classe.shared.exception.BusinessException;
+import com.diario.de.classe.shared.exception.ResourceNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class ClasseCronogramaService {
+
+    private final ClasseCronogramaRepository repository;
+    private final ClasseRepository classeRepository;
+    private final CronogramaAnualRepository cronogramaAnualRepository;
+
+    public ClasseCronogramaService(ClasseCronogramaRepository repository,
+                                   ClasseRepository classeRepository,
+                                   CronogramaAnualRepository cronogramaAnualRepository) {
+        this.repository = repository;
+        this.classeRepository = classeRepository;
+        this.cronogramaAnualRepository = cronogramaAnualRepository;
+    }
+
+    public List<ClasseCronogramaDTO> buscarTodos() {
+        return repository.findAll().stream().map(ClasseCronogramaDTO::new).toList();
+    }
+
+    public ClasseCronogramaDTO buscarPorId(Long id) {
+        return new ClasseCronogramaDTO(repository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Vínculo classe-cronograma não encontrado com id: " + id)));
+    }
+
+    public List<ClasseCronogramaDTO> buscarPorClasse(Long idClasse) {
+        return repository.findByClasse_IdClasse(idClasse)
+                .stream().map(ClasseCronogramaDTO::new).toList();
+    }
+
+    public List<ClasseCronogramaDTO> buscarPorCronograma(Long idCronograma) {
+        return repository.findByCronogramaAnual_IdCronogramaAnual(idCronograma)
+                .stream().map(ClasseCronogramaDTO::new).toList();
+    }
+
+    @Transactional
+    public ClasseCronogramaDTO vincular(Long idClasse, Long idCronograma) {
+        Classe classe = classeRepository.findById(idClasse)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Classe não encontrada com id: " + idClasse));
+
+        CronogramaAnual cronograma = cronogramaAnualRepository.findByIdCronogramaAnualAndAtivoTrue(idCronograma)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Cronograma anual não encontrado com id: " + idCronograma));
+
+        if (repository.existsByClasse_IdClasseAndCronogramaAnual_IdCronogramaAnual(idClasse, idCronograma)) {
+            throw new BusinessException(
+                    "Esta classe já está vinculada a este cronograma anual.");
+        }
+
+        ClasseCronograma vínculo = new ClasseCronograma();
+        vínculo.setClasse(classe);
+        vínculo.setCronogramaAnual(cronograma);
+
+        return new ClasseCronogramaDTO(repository.save(vínculo));
+    }
+
+    @Transactional
+    public void desvincular(Long id) {
+        ClasseCronograma existente = repository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Vínculo classe-cronograma não encontrado com id: " + id));
+        existente.setAtivo(false);
+        existente.setDeletedAt(LocalDateTime.now());
+        repository.save(existente);
+    }
+}

--- a/src/main/java/com/diario/de/classe/modules/cronograma/CronogramaAnualController.java
+++ b/src/main/java/com/diario/de/classe/modules/cronograma/CronogramaAnualController.java
@@ -1,0 +1,84 @@
+package com.diario.de.classe.modules.cronograma;
+
+import com.diario.de.classe.modules.cronograma.dto.CronogramaAnualDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/cronogramas-anuais")
+@Tag(name = "CronogramaAnual", description = "Gerenciamento do cronograma anual letivo da escola")
+public class CronogramaAnualController {
+
+    private final CronogramaAnualService service;
+
+    public CronogramaAnualController(CronogramaAnualService service) {
+        this.service = service;
+    }
+
+    @Operation(summary = "Listar todos os cronogramas anuais ativos")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<CronogramaAnualDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos()));
+    }
+
+    @Operation(summary = "Buscar cronograma anual por ID")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<CronogramaAnualDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarPorId(id)));
+    }
+
+    @Operation(summary = "Listar cronogramas por status (RASCUNHO, ATIVO, ENCERRADO)")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
+    @GetMapping("/status/{status}")
+    public ResponseEntity<ApiResponse<List<CronogramaAnualDTO>>> buscarPorStatus(
+            @PathVariable String status) {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarPorStatus(status)));
+    }
+
+    @Operation(summary = "Criar cronograma anual")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
+    @PostMapping
+    public ResponseEntity<ApiResponse<CronogramaAnualDTO>> criar(@RequestBody CronogramaAnualDTO dto) {
+        CronogramaAnual entity = new CronogramaAnual();
+        entity.setAno(dto.getAno());
+        entity.setDataInicio(dto.getDataInicio());
+        entity.setDataFim(dto.getDataFim());
+        entity.setDiasLetivosPrevistos(dto.getDiasLetivosPrevistos());
+        entity.setCargaHorariaPrevista(dto.getCargaHorariaPrevista());
+        entity.setStatus(dto.getStatus() != null ? dto.getStatus() : "RASCUNHO");
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.ok(service.criar(entity), "Cronograma anual criado com sucesso"));
+    }
+
+    @Operation(summary = "Atualizar cronograma anual")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse<CronogramaAnualDTO>> atualizar(
+            @PathVariable Long id, @RequestBody CronogramaAnualDTO dto) {
+        CronogramaAnual dados = new CronogramaAnual();
+        dados.setAno(dto.getAno());
+        dados.setDataInicio(dto.getDataInicio());
+        dados.setDataFim(dto.getDataFim());
+        dados.setDiasLetivosPrevistos(dto.getDiasLetivosPrevistos());
+        dados.setCargaHorariaPrevista(dto.getCargaHorariaPrevista());
+        dados.setStatus(dto.getStatus());
+        return ResponseEntity.ok(ApiResponse.ok(service.atualizar(id, dados)));
+    }
+
+    @Operation(summary = "Desativar cronograma anual (soft delete)")
+    @PreAuthorize("hasRole('ADMINISTRADOR')")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
+        service.deletar(id);
+        return ResponseEntity.ok(ApiResponse.ok(null, "Cronograma anual desativado com sucesso"));
+    }
+}

--- a/src/main/java/com/diario/de/classe/modules/cronograma/CronogramaAnualService.java
+++ b/src/main/java/com/diario/de/classe/modules/cronograma/CronogramaAnualService.java
@@ -1,0 +1,85 @@
+package com.diario.de.classe.modules.cronograma;
+
+import com.diario.de.classe.modules.cronograma.dto.CronogramaAnualDTO;
+import com.diario.de.classe.shared.exception.BusinessException;
+import com.diario.de.classe.shared.exception.ResourceNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class CronogramaAnualService {
+
+    private final CronogramaAnualRepository repository;
+
+    public CronogramaAnualService(CronogramaAnualRepository repository) {
+        this.repository = repository;
+    }
+
+    public List<CronogramaAnualDTO> buscarTodos() {
+        return repository.findAllByAtivoTrue().stream().map(CronogramaAnualDTO::new).toList();
+    }
+
+    public CronogramaAnualDTO buscarPorId(Long id) {
+        return new CronogramaAnualDTO(repository.findByIdCronogramaAnualAndAtivoTrue(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Cronograma anual não encontrado com id: " + id)));
+    }
+
+    public List<CronogramaAnualDTO> buscarPorStatus(String status) {
+        return repository.findAllByAtivoTrue().stream()
+                .filter(c -> status.equalsIgnoreCase(c.getStatus()))
+                .map(CronogramaAnualDTO::new)
+                .toList();
+    }
+
+    @Transactional
+    public CronogramaAnualDTO criar(CronogramaAnual dados) {
+        if ("ATIVO".equalsIgnoreCase(dados.getStatus())) {
+            boolean jaExisteAtivo = repository.findAllByAtivoTrue().stream()
+                    .anyMatch(c -> c.getAno().equals(dados.getAno()) && "ATIVO".equalsIgnoreCase(c.getStatus()));
+            if (jaExisteAtivo) {
+                throw new BusinessException(
+                        "Já existe um cronograma ATIVO para o ano " + dados.getAno() + ".");
+            }
+        }
+        return new CronogramaAnualDTO(repository.save(dados));
+    }
+
+    @Transactional
+    public CronogramaAnualDTO atualizar(Long id, CronogramaAnual dados) {
+        CronogramaAnual existente = repository.findByIdCronogramaAnualAndAtivoTrue(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Cronograma anual não encontrado com id: " + id));
+
+        if ("ATIVO".equalsIgnoreCase(dados.getStatus())
+                && !existente.getAno().equals(dados.getAno())) {
+            boolean jaExisteAtivo = repository.findAllByAtivoTrue().stream()
+                    .anyMatch(c -> !c.getIdCronogramaAnual().equals(id)
+                            && c.getAno().equals(dados.getAno())
+                            && "ATIVO".equalsIgnoreCase(c.getStatus()));
+            if (jaExisteAtivo) {
+                throw new BusinessException(
+                        "Já existe um cronograma ATIVO para o ano " + dados.getAno() + ".");
+            }
+        }
+
+        existente.setAno(dados.getAno());
+        existente.setDataInicio(dados.getDataInicio());
+        existente.setDataFim(dados.getDataFim());
+        existente.setDiasLetivosPrevistos(dados.getDiasLetivosPrevistos());
+        existente.setCargaHorariaPrevista(dados.getCargaHorariaPrevista());
+        existente.setStatus(dados.getStatus());
+
+        return new CronogramaAnualDTO(repository.save(existente));
+    }
+
+    @Transactional
+    public void deletar(Long id) {
+        CronogramaAnual existente = repository.findByIdCronogramaAnualAndAtivoTrue(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Cronograma anual não encontrado com id: " + id));
+        existente.setAtivo(false);
+        existente.setDeletedAt(LocalDateTime.now());
+        repository.save(existente);
+    }
+}

--- a/src/main/java/com/diario/de/classe/modules/cronograma/EventoCalendarioController.java
+++ b/src/main/java/com/diario/de/classe/modules/cronograma/EventoCalendarioController.java
@@ -1,0 +1,87 @@
+package com.diario.de.classe.modules.cronograma;
+
+import com.diario.de.classe.modules.cronograma.dto.EventoCalendarioDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/eventos-calendario")
+@Tag(name = "EventoCalendario", description = "Gerenciamento de eventos do calendário escolar (feriados, recessos, eventos)")
+public class EventoCalendarioController {
+
+    private final EventoCalendarioService service;
+
+    public EventoCalendarioController(EventoCalendarioService service) {
+        this.service = service;
+    }
+
+    @Operation(summary = "Listar todos os eventos de calendário")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<EventoCalendarioDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos()));
+    }
+
+    @Operation(summary = "Buscar evento por ID")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<EventoCalendarioDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarPorId(id)));
+    }
+
+    @Operation(summary = "Listar eventos de um cronograma, ordenados por data de início")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
+    @GetMapping("/cronograma/{id}")
+    public ResponseEntity<ApiResponse<List<EventoCalendarioDTO>>> buscarPorCronograma(
+            @PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarPorCronograma(id)));
+    }
+
+    @Operation(summary = "Criar evento de calendário")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
+    @PostMapping
+    public ResponseEntity<ApiResponse<EventoCalendarioDTO>> criar(@RequestBody EventoCalendarioDTO dto) {
+        EventoCalendario entity = new EventoCalendario();
+        entity.setTitulo(dto.getTitulo());
+        entity.setDescricao(dto.getDescricao());
+        entity.setDataInicio(dto.getDataInicio());
+        entity.setDataFim(dto.getDataFim());
+        entity.setTipoEvento(dto.getTipoEvento());
+        entity.setEhLetivo(dto.getEhLetivo() != null ? dto.getEhLetivo() : false);
+        entity.setCor(dto.getCor());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.ok(service.criar(entity, dto.getIdCronogramaAnual()),
+                        "Evento de calendário criado com sucesso"));
+    }
+
+    @Operation(summary = "Atualizar evento de calendário")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse<EventoCalendarioDTO>> atualizar(
+            @PathVariable Long id, @RequestBody EventoCalendarioDTO dto) {
+        EventoCalendario dados = new EventoCalendario();
+        dados.setTitulo(dto.getTitulo());
+        dados.setDescricao(dto.getDescricao());
+        dados.setDataInicio(dto.getDataInicio());
+        dados.setDataFim(dto.getDataFim());
+        dados.setTipoEvento(dto.getTipoEvento());
+        dados.setEhLetivo(dto.getEhLetivo() != null ? dto.getEhLetivo() : false);
+        dados.setCor(dto.getCor());
+        return ResponseEntity.ok(ApiResponse.ok(service.atualizar(id, dados)));
+    }
+
+    @Operation(summary = "Desativar evento de calendário (soft delete)")
+    @PreAuthorize("hasRole('ADMINISTRADOR')")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
+        service.deletar(id);
+        return ResponseEntity.ok(ApiResponse.ok(null, "Evento de calendário desativado com sucesso"));
+    }
+}

--- a/src/main/java/com/diario/de/classe/modules/cronograma/EventoCalendarioService.java
+++ b/src/main/java/com/diario/de/classe/modules/cronograma/EventoCalendarioService.java
@@ -1,0 +1,73 @@
+package com.diario.de.classe.modules.cronograma;
+
+import com.diario.de.classe.modules.cronograma.dto.EventoCalendarioDTO;
+import com.diario.de.classe.shared.exception.ResourceNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class EventoCalendarioService {
+
+    private final EventoCalendarioRepository repository;
+    private final CronogramaAnualRepository cronogramaAnualRepository;
+
+    public EventoCalendarioService(EventoCalendarioRepository repository,
+                                   CronogramaAnualRepository cronogramaAnualRepository) {
+        this.repository = repository;
+        this.cronogramaAnualRepository = cronogramaAnualRepository;
+    }
+
+    public List<EventoCalendarioDTO> buscarTodos() {
+        return repository.findAll().stream().map(EventoCalendarioDTO::new).toList();
+    }
+
+    public EventoCalendarioDTO buscarPorId(Long id) {
+        return new EventoCalendarioDTO(repository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Evento de calendário não encontrado com id: " + id)));
+    }
+
+    public List<EventoCalendarioDTO> buscarPorCronograma(Long idCronograma) {
+        return repository.findByCronogramaAnual_IdCronogramaAnualOrderByDataInicio(idCronograma)
+                .stream().map(EventoCalendarioDTO::new).toList();
+    }
+
+    @Transactional
+    public EventoCalendarioDTO criar(EventoCalendario dados, Long idCronograma) {
+        CronogramaAnual cronograma = cronogramaAnualRepository.findByIdCronogramaAnualAndAtivoTrue(idCronograma)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Cronograma anual não encontrado com id: " + idCronograma));
+        dados.setCronogramaAnual(cronograma);
+        return new EventoCalendarioDTO(repository.save(dados));
+    }
+
+    @Transactional
+    public EventoCalendarioDTO atualizar(Long id, EventoCalendario dados) {
+        EventoCalendario existente = repository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Evento de calendário não encontrado com id: " + id));
+
+        existente.setTitulo(dados.getTitulo());
+        existente.setDescricao(dados.getDescricao());
+        existente.setDataInicio(dados.getDataInicio());
+        existente.setDataFim(dados.getDataFim());
+        existente.setTipoEvento(dados.getTipoEvento());
+        existente.setEhLetivo(dados.getEhLetivo());
+        existente.setCor(dados.getCor());
+
+        return new EventoCalendarioDTO(repository.save(existente));
+    }
+
+    @Transactional
+    public void deletar(Long id) {
+        EventoCalendario existente = repository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Evento de calendário não encontrado com id: " + id));
+        existente.setAtivo(false);
+        existente.setDeletedAt(LocalDateTime.now());
+        repository.save(existente);
+    }
+}

--- a/src/main/java/com/diario/de/classe/modules/cronograma/GradeCurricularController.java
+++ b/src/main/java/com/diario/de/classe/modules/cronograma/GradeCurricularController.java
@@ -1,0 +1,81 @@
+package com.diario.de.classe.modules.cronograma;
+
+import com.diario.de.classe.modules.cronograma.dto.GradeCurricularDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/grades-curriculares")
+@Tag(name = "GradeCurricular", description = "Grade de horários semanais fixos de uma classe (dia, número de aula, horário)")
+public class GradeCurricularController {
+
+    private final GradeCurricularService service;
+
+    public GradeCurricularController(GradeCurricularService service) {
+        this.service = service;
+    }
+
+    @Operation(summary = "Listar todas as grades curriculares")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<GradeCurricularDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos()));
+    }
+
+    @Operation(summary = "Buscar grade curricular por ID")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<GradeCurricularDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarPorId(id)));
+    }
+
+    @Operation(summary = "Listar grade de uma classe, ordenada por dia e número de aula")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
+    @GetMapping("/classe/{idClasse}")
+    public ResponseEntity<ApiResponse<List<GradeCurricularDTO>>> buscarPorClasse(
+            @PathVariable Long idClasse) {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarPorClasse(idClasse)));
+    }
+
+    @Operation(summary = "Criar horário na grade curricular")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
+    @PostMapping
+    public ResponseEntity<ApiResponse<GradeCurricularDTO>> criar(@RequestBody GradeCurricularDTO dto) {
+        GradeCurricular entity = new GradeCurricular();
+        entity.setDiaSemana(dto.getDiaSemana());
+        entity.setNumeroAula(dto.getNumeroAula());
+        entity.setHorarioInicio(dto.getHorarioInicio());
+        entity.setHorarioFim(dto.getHorarioFim());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.ok(service.criar(entity, dto.getIdClasse()),
+                        "Horário adicionado à grade curricular com sucesso"));
+    }
+
+    @Operation(summary = "Atualizar horário na grade curricular")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse<GradeCurricularDTO>> atualizar(
+            @PathVariable Long id, @RequestBody GradeCurricularDTO dto) {
+        GradeCurricular dados = new GradeCurricular();
+        dados.setDiaSemana(dto.getDiaSemana());
+        dados.setNumeroAula(dto.getNumeroAula());
+        dados.setHorarioInicio(dto.getHorarioInicio());
+        dados.setHorarioFim(dto.getHorarioFim());
+        return ResponseEntity.ok(ApiResponse.ok(service.atualizar(id, dados)));
+    }
+
+    @Operation(summary = "Remover horário da grade curricular (soft delete)")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
+        service.deletar(id);
+        return ResponseEntity.ok(ApiResponse.ok(null, "Horário removido da grade curricular com sucesso"));
+    }
+}

--- a/src/main/java/com/diario/de/classe/modules/cronograma/GradeCurricularService.java
+++ b/src/main/java/com/diario/de/classe/modules/cronograma/GradeCurricularService.java
@@ -1,0 +1,85 @@
+package com.diario.de.classe.modules.cronograma;
+
+import com.diario.de.classe.modules.cronograma.dto.GradeCurricularDTO;
+import com.diario.de.classe.modules.turma.Classe;
+import com.diario.de.classe.modules.turma.ClasseRepository;
+import com.diario.de.classe.shared.exception.BusinessException;
+import com.diario.de.classe.shared.exception.ResourceNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+public class GradeCurricularService {
+
+    private final GradeCurricularRepository repository;
+    private final ClasseRepository classeRepository;
+
+    public GradeCurricularService(GradeCurricularRepository repository,
+                                  ClasseRepository classeRepository) {
+        this.repository = repository;
+        this.classeRepository = classeRepository;
+    }
+
+    public List<GradeCurricularDTO> buscarTodos() {
+        return repository.findAll().stream().map(GradeCurricularDTO::new).toList();
+    }
+
+    public GradeCurricularDTO buscarPorId(Long id) {
+        return new GradeCurricularDTO(repository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Grade curricular não encontrada com id: " + id)));
+    }
+
+    public List<GradeCurricularDTO> buscarPorClasse(Long idClasse) {
+        return repository.findByClasse_IdClasse(idClasse).stream()
+                .sorted(Comparator.comparingInt(GradeCurricular::getDiaSemana)
+                        .thenComparingInt(GradeCurricular::getNumeroAula))
+                .map(GradeCurricularDTO::new)
+                .toList();
+    }
+
+    @Transactional
+    public GradeCurricularDTO criar(GradeCurricular dados, Long idClasse) {
+        Classe classe = classeRepository.findById(idClasse)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Classe não encontrada com id: " + idClasse));
+
+        if (repository.existsByClasse_IdClasseAndDiaSemanaAndNumeroAula(
+                idClasse, dados.getDiaSemana(), dados.getNumeroAula())) {
+            throw new BusinessException(
+                    "Já existe um horário para o dia " + dados.getDiaSemana()
+                    + ", aula " + dados.getNumeroAula() + " nesta classe.");
+        }
+
+        dados.setClasse(classe);
+        return new GradeCurricularDTO(repository.save(dados));
+    }
+
+    @Transactional
+    public GradeCurricularDTO atualizar(Long id, GradeCurricular dados) {
+        GradeCurricular existente = repository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Grade curricular não encontrada com id: " + id));
+
+        existente.setDiaSemana(dados.getDiaSemana());
+        existente.setNumeroAula(dados.getNumeroAula());
+        existente.setHorarioInicio(dados.getHorarioInicio());
+        existente.setHorarioFim(dados.getHorarioFim());
+
+        return new GradeCurricularDTO(repository.save(existente));
+    }
+
+    @Transactional
+    public void deletar(Long id) {
+        GradeCurricular existente = repository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Grade curricular não encontrada com id: " + id));
+        existente.setAtivo(false);
+        existente.setDeletedAt(LocalDateTime.now());
+        repository.save(existente);
+    }
+}

--- a/src/main/java/com/diario/de/classe/modules/cronograma/PeriodoLetivoController.java
+++ b/src/main/java/com/diario/de/classe/modules/cronograma/PeriodoLetivoController.java
@@ -1,0 +1,83 @@
+package com.diario.de.classe.modules.cronograma;
+
+import com.diario.de.classe.modules.cronograma.dto.PeriodoLetivoDTO;
+import com.diario.de.classe.shared.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/periodos-letivos")
+@Tag(name = "PeriodoLetivo", description = "Gerenciamento de períodos letivos (bimestres, trimestres, semestres)")
+public class PeriodoLetivoController {
+
+    private final PeriodoLetivoService service;
+
+    public PeriodoLetivoController(PeriodoLetivoService service) {
+        this.service = service;
+    }
+
+    @Operation(summary = "Listar todos os períodos letivos")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<PeriodoLetivoDTO>>> listar() {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarTodos()));
+    }
+
+    @Operation(summary = "Buscar período letivo por ID")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<PeriodoLetivoDTO>> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarPorId(id)));
+    }
+
+    @Operation(summary = "Listar períodos de um cronograma, ordenados pela sequência")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR', 'PROFESSOR')")
+    @GetMapping("/cronograma/{idCronograma}")
+    public ResponseEntity<ApiResponse<List<PeriodoLetivoDTO>>> buscarPorCronograma(
+            @PathVariable Long idCronograma) {
+        return ResponseEntity.ok(ApiResponse.ok(service.buscarPorCronograma(idCronograma)));
+    }
+
+    @Operation(summary = "Criar período letivo")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
+    @PostMapping
+    public ResponseEntity<ApiResponse<PeriodoLetivoDTO>> criar(@RequestBody PeriodoLetivoDTO dto) {
+        PeriodoLetivo entity = new PeriodoLetivo();
+        entity.setNome(dto.getNome());
+        entity.setTipo(dto.getTipo());
+        entity.setDataInicio(dto.getDataInicio());
+        entity.setDataFim(dto.getDataFim());
+        entity.setOrdem(dto.getOrdem());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.ok(service.criar(entity, dto.getIdCronogramaAnual()),
+                        "Período letivo criado com sucesso"));
+    }
+
+    @Operation(summary = "Atualizar período letivo")
+    @PreAuthorize("hasAnyRole('ADMINISTRADOR', 'COORDENADOR')")
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse<PeriodoLetivoDTO>> atualizar(
+            @PathVariable Long id, @RequestBody PeriodoLetivoDTO dto) {
+        PeriodoLetivo dados = new PeriodoLetivo();
+        dados.setNome(dto.getNome());
+        dados.setTipo(dto.getTipo());
+        dados.setDataInicio(dto.getDataInicio());
+        dados.setDataFim(dto.getDataFim());
+        dados.setOrdem(dto.getOrdem());
+        return ResponseEntity.ok(ApiResponse.ok(service.atualizar(id, dados)));
+    }
+
+    @Operation(summary = "Desativar período letivo (soft delete)")
+    @PreAuthorize("hasRole('ADMINISTRADOR')")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> deletar(@PathVariable Long id) {
+        service.deletar(id);
+        return ResponseEntity.ok(ApiResponse.ok(null, "Período letivo desativado com sucesso"));
+    }
+}

--- a/src/main/java/com/diario/de/classe/modules/cronograma/PeriodoLetivoService.java
+++ b/src/main/java/com/diario/de/classe/modules/cronograma/PeriodoLetivoService.java
@@ -1,0 +1,83 @@
+package com.diario.de.classe.modules.cronograma;
+
+import com.diario.de.classe.modules.cronograma.dto.PeriodoLetivoDTO;
+import com.diario.de.classe.shared.exception.BusinessException;
+import com.diario.de.classe.shared.exception.ResourceNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class PeriodoLetivoService {
+
+    private final PeriodoLetivoRepository repository;
+    private final CronogramaAnualRepository cronogramaAnualRepository;
+
+    public PeriodoLetivoService(PeriodoLetivoRepository repository,
+                                CronogramaAnualRepository cronogramaAnualRepository) {
+        this.repository = repository;
+        this.cronogramaAnualRepository = cronogramaAnualRepository;
+    }
+
+    public List<PeriodoLetivoDTO> buscarTodos() {
+        return repository.findAll().stream().map(PeriodoLetivoDTO::new).toList();
+    }
+
+    public PeriodoLetivoDTO buscarPorId(Long id) {
+        return new PeriodoLetivoDTO(repository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Período letivo não encontrado com id: " + id)));
+    }
+
+    public List<PeriodoLetivoDTO> buscarPorCronograma(Long idCronograma) {
+        return repository.findByCronogramaAnual_IdCronogramaAnualOrderByOrdem(idCronograma)
+                .stream().map(PeriodoLetivoDTO::new).toList();
+    }
+
+    @Transactional
+    public PeriodoLetivoDTO criar(PeriodoLetivo dados, Long idCronograma) {
+        CronogramaAnual cronograma = cronogramaAnualRepository.findByIdCronogramaAnualAndAtivoTrue(idCronograma)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Cronograma anual não encontrado com id: " + idCronograma));
+
+        if (repository.existsByCronogramaAnual_IdCronogramaAnualAndOrdem(idCronograma, dados.getOrdem())) {
+            throw new BusinessException(
+                    "Já existe um período com ordem " + dados.getOrdem()
+                    + " neste cronograma.");
+        }
+
+        if (dados.getDataInicio().isBefore(cronograma.getDataInicio())
+                || dados.getDataFim().isAfter(cronograma.getDataFim())) {
+            throw new BusinessException(
+                    "As datas do período devem estar dentro do intervalo do cronograma ("
+                    + cronograma.getDataInicio() + " — " + cronograma.getDataFim() + ").");
+        }
+
+        dados.setCronogramaAnual(cronograma);
+        return new PeriodoLetivoDTO(repository.save(dados));
+    }
+
+    @Transactional
+    public PeriodoLetivoDTO atualizar(Long id, PeriodoLetivo dados) {
+        PeriodoLetivo existente = repository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Período letivo não encontrado com id: " + id));
+
+        existente.setNome(dados.getNome());
+        existente.setTipo(dados.getTipo());
+        existente.setDataInicio(dados.getDataInicio());
+        existente.setDataFim(dados.getDataFim());
+        existente.setOrdem(dados.getOrdem());
+
+        return new PeriodoLetivoDTO(repository.save(existente));
+    }
+
+    @Transactional
+    public void deletar(Long id) {
+        PeriodoLetivo existente = repository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Período letivo não encontrado com id: " + id));
+        existente.setAtivo(false);
+        existente.setDeletedAt(LocalDateTime.now());
+        repository.save(existente);
+    }
+}

--- a/src/main/java/com/diario/de/classe/modules/cronograma/dto/AulaDTO.java
+++ b/src/main/java/com/diario/de/classe/modules/cronograma/dto/AulaDTO.java
@@ -1,0 +1,47 @@
+package com.diario.de.classe.modules.cronograma.dto;
+
+import com.diario.de.classe.modules.cronograma.Aula;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Data;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+
+@Data
+public class AulaDTO implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Long idAula;
+    private Long idClasse;
+    private Long idPeriodoLetivo;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate dataAula;
+
+    private Integer numeroAula;
+    private String conteudoMinistrado;
+    private Boolean chamadaEncerrada;
+    private Long idRegistradoPor;
+    private String nomeRegistradoPor;
+    private Boolean ativo;
+
+    public AulaDTO() {}
+
+    public AulaDTO(Aula entity) {
+        if (entity != null) {
+            this.idAula = entity.getIdAula();
+            this.idClasse = entity.getClasse() != null ? entity.getClasse().getIdClasse() : null;
+            this.idPeriodoLetivo = entity.getPeriodoLetivo() != null
+                    ? entity.getPeriodoLetivo().getIdPeriodoLetivo() : null;
+            this.dataAula = entity.getDataAula();
+            this.numeroAula = entity.getNumeroAula();
+            this.conteudoMinistrado = entity.getConteudoMinistrado();
+            this.chamadaEncerrada = entity.getChamadaEncerrada();
+            this.idRegistradoPor = entity.getRegistradoPor() != null
+                    ? entity.getRegistradoPor().getIdPessoa() : null;
+            this.nomeRegistradoPor = entity.getRegistradoPor() != null
+                    ? entity.getRegistradoPor().getNome() : null;
+            this.ativo = entity.getAtivo();
+        }
+    }
+}

--- a/src/main/java/com/diario/de/classe/modules/cronograma/dto/ClasseCronogramaDTO.java
+++ b/src/main/java/com/diario/de/classe/modules/cronograma/dto/ClasseCronogramaDTO.java
@@ -1,0 +1,28 @@
+package com.diario.de.classe.modules.cronograma.dto;
+
+import com.diario.de.classe.modules.cronograma.ClasseCronograma;
+import lombok.Data;
+
+import java.io.Serializable;
+
+@Data
+public class ClasseCronogramaDTO implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Long idClasseCronograma;
+    private Long idClasse;
+    private Long idCronogramaAnual;
+    private Boolean ativo;
+
+    public ClasseCronogramaDTO() {}
+
+    public ClasseCronogramaDTO(ClasseCronograma entity) {
+        if (entity != null) {
+            this.idClasseCronograma = entity.getIdClasseCronograma();
+            this.idClasse = entity.getClasse() != null ? entity.getClasse().getIdClasse() : null;
+            this.idCronogramaAnual = entity.getCronogramaAnual() != null
+                    ? entity.getCronogramaAnual().getIdCronogramaAnual() : null;
+            this.ativo = entity.getAtivo();
+        }
+    }
+}

--- a/src/main/java/com/diario/de/classe/modules/cronograma/dto/CronogramaAnualDTO.java
+++ b/src/main/java/com/diario/de/classe/modules/cronograma/dto/CronogramaAnualDTO.java
@@ -1,0 +1,42 @@
+package com.diario.de.classe.modules.cronograma.dto;
+
+import com.diario.de.classe.modules.cronograma.CronogramaAnual;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Data;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+
+@Data
+public class CronogramaAnualDTO implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Long idCronogramaAnual;
+    private Integer ano;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate dataInicio;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate dataFim;
+
+    private Integer diasLetivosPrevistos;
+    private Integer cargaHorariaPrevista;
+    private String status;
+    private Boolean ativo;
+
+    public CronogramaAnualDTO() {}
+
+    public CronogramaAnualDTO(CronogramaAnual entity) {
+        if (entity != null) {
+            this.idCronogramaAnual = entity.getIdCronogramaAnual();
+            this.ano = entity.getAno();
+            this.dataInicio = entity.getDataInicio();
+            this.dataFim = entity.getDataFim();
+            this.diasLetivosPrevistos = entity.getDiasLetivosPrevistos();
+            this.cargaHorariaPrevista = entity.getCargaHorariaPrevista();
+            this.status = entity.getStatus();
+            this.ativo = entity.getAtivo();
+        }
+    }
+}

--- a/src/main/java/com/diario/de/classe/modules/cronograma/dto/EventoCalendarioDTO.java
+++ b/src/main/java/com/diario/de/classe/modules/cronograma/dto/EventoCalendarioDTO.java
@@ -1,0 +1,47 @@
+package com.diario.de.classe.modules.cronograma.dto;
+
+import com.diario.de.classe.modules.cronograma.EventoCalendario;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Data;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+
+@Data
+public class EventoCalendarioDTO implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Long idEventoCalendario;
+    private Long idCronogramaAnual;
+    private String titulo;
+    private String descricao;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate dataInicio;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate dataFim;
+
+    private String tipoEvento;
+    private Boolean ehLetivo;
+    private String cor;
+    private Boolean ativo;
+
+    public EventoCalendarioDTO() {}
+
+    public EventoCalendarioDTO(EventoCalendario entity) {
+        if (entity != null) {
+            this.idEventoCalendario = entity.getIdEventoCalendario();
+            this.idCronogramaAnual = entity.getCronogramaAnual() != null
+                    ? entity.getCronogramaAnual().getIdCronogramaAnual() : null;
+            this.titulo = entity.getTitulo();
+            this.descricao = entity.getDescricao();
+            this.dataInicio = entity.getDataInicio();
+            this.dataFim = entity.getDataFim();
+            this.tipoEvento = entity.getTipoEvento();
+            this.ehLetivo = entity.getEhLetivo();
+            this.cor = entity.getCor();
+            this.ativo = entity.getAtivo();
+        }
+    }
+}

--- a/src/main/java/com/diario/de/classe/modules/cronograma/dto/GradeCurricularDTO.java
+++ b/src/main/java/com/diario/de/classe/modules/cronograma/dto/GradeCurricularDTO.java
@@ -1,0 +1,40 @@
+package com.diario.de.classe.modules.cronograma.dto;
+
+import com.diario.de.classe.modules.cronograma.GradeCurricular;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Data;
+
+import java.io.Serializable;
+import java.time.LocalTime;
+
+@Data
+public class GradeCurricularDTO implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Long idGradeCurricular;
+    private Long idClasse;
+    private Integer diaSemana;
+    private Integer numeroAula;
+
+    @JsonFormat(pattern = "HH:mm:ss")
+    private LocalTime horarioInicio;
+
+    @JsonFormat(pattern = "HH:mm:ss")
+    private LocalTime horarioFim;
+
+    private Boolean ativo;
+
+    public GradeCurricularDTO() {}
+
+    public GradeCurricularDTO(GradeCurricular entity) {
+        if (entity != null) {
+            this.idGradeCurricular = entity.getIdGradeCurricular();
+            this.idClasse = entity.getClasse() != null ? entity.getClasse().getIdClasse() : null;
+            this.diaSemana = entity.getDiaSemana();
+            this.numeroAula = entity.getNumeroAula();
+            this.horarioInicio = entity.getHorarioInicio();
+            this.horarioFim = entity.getHorarioFim();
+            this.ativo = entity.getAtivo();
+        }
+    }
+}

--- a/src/main/java/com/diario/de/classe/modules/cronograma/dto/PeriodoLetivoDTO.java
+++ b/src/main/java/com/diario/de/classe/modules/cronograma/dto/PeriodoLetivoDTO.java
@@ -1,0 +1,43 @@
+package com.diario.de.classe.modules.cronograma.dto;
+
+import com.diario.de.classe.modules.cronograma.PeriodoLetivo;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Data;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+
+@Data
+public class PeriodoLetivoDTO implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Long idPeriodoLetivo;
+    private Long idCronogramaAnual;
+    private String nome;
+    private String tipo;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate dataInicio;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate dataFim;
+
+    private Integer ordem;
+    private Boolean ativo;
+
+    public PeriodoLetivoDTO() {}
+
+    public PeriodoLetivoDTO(PeriodoLetivo entity) {
+        if (entity != null) {
+            this.idPeriodoLetivo = entity.getIdPeriodoLetivo();
+            this.idCronogramaAnual = entity.getCronogramaAnual() != null
+                    ? entity.getCronogramaAnual().getIdCronogramaAnual() : null;
+            this.nome = entity.getNome();
+            this.tipo = entity.getTipo();
+            this.dataInicio = entity.getDataInicio();
+            this.dataFim = entity.getDataFim();
+            this.ordem = entity.getOrdem();
+            this.ativo = entity.getAtivo();
+        }
+    }
+}


### PR DESCRIPTION
Camada de aplicação completa para as 6 entidades do módulo cronograma:

DTOs (dto/):
- CronogramaAnualDTO — @JsonFormat para dataInicio/dataFim
- PeriodoLetivoDTO — resolve idCronogramaAnual da FK
- EventoCalendarioDTO — mapeia ehLetivo, cor, tipoEvento
- ClasseCronogramaDTO — mapeia idClasse e idCronogramaAnual das FKs
- GradeCurricularDTO — @JsonFormat para horarioInicio/horarioFim (HH:mm:ss)
- AulaDTO — expõe idRegistradoPor e nomeRegistradoPor resolvidos da Pessoa

Services:
- CronogramaAnualService — valida duplicidade de ATIVO por ano; soft delete
- PeriodoLetivoService — valida ordem única e datas dentro do cronograma pai
- EventoCalendarioService — vincula ao cronograma; soft delete
- ClasseCronogramaService — valida vínculo duplicado classe/cronograma
- GradeCurricularService — valida duplicata por classe/dia/numeroAula; ordenação em memória
- AulaService — valida duplicata, datas dentro do período, chamadaEncerrada em PUT/DELETE/PATCH

Controllers:
- GET /v1/cronogramas-anuais, /status/{status}, /{id}; POST, PUT, DELETE
- GET /v1/periodos-letivos, /cronograma/{id}, /{id}; POST, PUT, DELETE
- GET /v1/eventos-calendario, /cronograma/{id}, /{id}; POST, PUT, DELETE
- GET /v1/classes-cronograma, /classe/{id}, /cronograma/{id}, /{id}; POST, DELETE
- GET /v1/grades-curriculares, /classe/{id}, /{id}; POST, PUT, DELETE
- GET /v1/aulas, /classe/{id}/data/{data}, /periodo/{id}/classe/{id}, /{id}; POST, PUT, PATCH /encerrar, DELETE